### PR TITLE
Switch to ruff and basedpyright for linting and type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# ruff
+.ruff_cache/
 node_modules/
 
 **/*@neomake*.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Vision Transformer (ViT) implementation in native PyTorch, optimized with `torch.compile`. This implementation does not use a CLS token - features are returned directly from the transformer. Supports modern enhancements: RMSNorm, SwiGLU, Squared ReLU, register tokens, and multiple position encodings (RoPE, Fourier, Learnable).
+
+## Common Commands
+
+```bash
+# Setup
+make init              # Initialize environment and install all dependencies (uses uv)
+
+# Development
+make check             # Full check: style + quality + types + tests
+make style             # Auto-format code (autoflake, isort, autopep8, black)
+make quality           # Check formatting without changes
+make types             # Static type checking with pyright
+make test              # Run unit tests with coverage
+make test-<pattern>    # Run tests matching pattern (e.g., make test-attention)
+make test-pdb-<pattern> # Debug tests with PDB
+
+# Benchmarking
+uv sync --group benchmarking
+vit-benchmark --configs config.yaml --resolutions 224,224 --device cuda
+```
+
+## Architecture
+
+**Core flow**: Images → PatchEmbed → Transformer Encoder → ViTFeatures → Heads
+
+Key modules in `vit/`:
+- `vit.py` - Main `ViT` model class and `ViTConfig` dataclass (YAML-serializable)
+- `transformer.py` - `TransformerEncoderLayer` and `TransformerDecoderLayer`
+- `attention.py` - `Attention`, `AttentionResidual`, `CrossAttention`
+- `head.py` - Output heads (`Head`, `TransposedConv2dHead`, `UpsampleHead`) with configs
+- `pos_enc.py` - Position encoders (`RopePositionEmbedding`, `FourierPosition`, `LearnablePosition`)
+- `fused.py` - Fused operations (`NormMLP` combines norm + linear + activation)
+- `tokens.py` - Register token handling
+
+**Output structure**: `ViT.forward()` returns a `ViTFeatures` dataclass, not raw tensors.
+
+**Heads system**: Heads are configured via `HeadConfig` dict in `ViTConfig.heads` and accessed via `model.heads["name"]`.
+
+## Code Style
+
+- Line length: 120 characters (ruff)
+- Type checking: basedpyright with Python 3.14 target
+- Linting and formatting: ruff (replaces black, isort, flake8, autopep8, autoflake)
+- Always run `make style` before committing
+- Test markers: `@pytest.mark.ci_skip` (skip in CI), `@pytest.mark.cuda` (requires GPU)
+
+## Key Patterns
+
+- **Config-driven instantiation**: Use `ViTConfig.instantiate()` and `HeadConfig.instantiate()` rather than direct class construction
+- **torch.compile friendly**: Custom implementations avoid einops; designed for compilation
+- **No CLS token**: All token pooling happens in heads, not the transformer
+- **Position encoding**: Default is RoPE; configurable via `pos_enc` parameter

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,12 @@ init: ## pulls submodules and initializes virtual environment
 
 quality:
 	$(MAKE) clean
-	$(PYTHON) -m black --check $(QUALITY_DIRS)
-	$(PYTHON) -m autopep8 -a $(QUALITY_DIRS)
+	uv run ruff check $(QUALITY_DIRS)
+	uv run ruff format --check $(QUALITY_DIRS)
 
 style:
-	$(PYTHON) -m autoflake -r -i $(QUALITY_DIRS)
-	$(PYTHON) -m isort $(QUALITY_DIRS)
-	$(PYTHON) -m autopep8 -a $(QUALITY_DIRS)
-	$(PYTHON) -m black $(QUALITY_DIRS)
+	uv run ruff check --fix $(QUALITY_DIRS)
+	uv run ruff format $(QUALITY_DIRS)
 
 test: ## run unit tests
 	$(PYTHON) -m pytest \
@@ -74,7 +72,7 @@ test-ci: ## runs CI-only tests
 		./tests/
 
 types: ## run static type checking
-	uv run pyright 
+	uv run basedpyright 
 
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Benchmarking tools for ViT models."""
 
 from .benchmark import (

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Core benchmarking functions for ViT models."""
 
 import time

--- a/benchmark/cli.py
+++ b/benchmark/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """CLI tool for running ViT benchmarks."""
 
 import argparse

--- a/benchmark/plotting.py
+++ b/benchmark/plotting.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Plotting functions for benchmark results."""
 
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,34 +20,27 @@ readme = "README.md"
 license = {text = "Apache"}
 dynamic = ["version"]
 
-[tool.autoflake]
-remove-all-unused-imports = true
-remove-unused-variables = true
-exclude = ["_version.py"]
-
-[tool.autopep8]
-max_line_length = 120
-ignore = "E501,W6,E203"
-in-place = true
-recursive = true
-aggressive = 3
-exclude = "_version.py"
-
-[tool.black]
+[tool.ruff]
 line-length = 120
-extend-exclude = "_version.py"
+target-version = "py311"
+extend-exclude = ["_version.py"]
 
-[tool.isort]
-ensure_newline_before_comments = true
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 119
-lines_after_imports = 2
-multi_line_output = 3
-use_parentheses = false
-skip_glob = ["*/_version.py"]
+[tool.ruff.lint]
+select = [
+  "E",      # pycodestyle errors
+  "W",      # pycodestyle warnings
+  "F",      # pyflakes
+  "I",      # isort
+  "UP",     # pyupgrade
+]
+ignore = ["E501"]  # line too long (handled by formatter)
 
-[tool.pyright]
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+force-single-line = false
+combine-as-imports = true
+
+[tool.basedpyright]
 include = ["vit", "tests", "benchmark"]
 exclude = [
   "**/node_modules",
@@ -55,9 +48,9 @@ exclude = [
   "**/.pytest_cache",
   "**/_version.py",
 ]
-ignore = ["src/oldstuff"]
 pythonVersion = "3.14"
 pythonPlatform = "Linux"
+typeCheckingMode = "standard"
 
 [tool.hatch.version]
 source = "vcs"
@@ -82,12 +75,8 @@ benchmarking = [
 ]
 
 dev = [
-    "autoflake",
-    "autopep8",
-    "black",
-    "flake8",
-    "isort",
-    "pyright",
+    "ruff",
+    "basedpyright",
     "pytest",
     "pytest-mock",
     "pytest-cov",

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -10,7 +10,6 @@ from vit.attention import AttentivePool, CrossAttention, SelfAttention
 
 
 class TestSelfAttention:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     def test_forward(self, dtype, device):
         B, L, D = 16, 128, 128
@@ -76,7 +75,6 @@ class TestSelfAttention:
 
 
 class TestCrossAttention:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     def test_forward(self, dtype, device):
         B, L, D = 16, 128, 128
@@ -152,7 +150,6 @@ class TestCrossAttention:
 
 
 class TestAttentivePool:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     def test_forward(self, dtype, device):
         B, L, D = 16, 128, 128

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Tests for benchmarking functionality."""
 
 from pathlib import Path

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -10,7 +10,6 @@ from vit.fused import NormLinear, NormMLP
 
 
 class TestNormLinear:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     def test_forward(self, device, dtype):
         layer_norm_linear = NormLinear(10, 20).to(device)
@@ -62,7 +61,6 @@ class TestNormLinear:
 
 
 class TestNormMLP:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     @pytest.mark.parametrize("activation", ["relu", "silu", "gelu", "srelu", "reglu", "swiglu", "geglu", "openswiglu"])
     def test_forward(self, device, dtype, activation):

--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -13,7 +13,6 @@ from vit.vit import ViTConfig
 
 
 class TestHeadConfig:
-
     def test_instantiate(self):
         config = HeadConfig(out_features=128)
         vit_config = ViTConfig(
@@ -48,7 +47,6 @@ class TestHeadConfig:
 
 
 class TestTransposedConv2dHeadConfig:
-
     def test_instantiate(self):
         config = TransposedConv2dHeadConfig(out_features=64, kernel_size=4, stride=2, padding=1)
         vit_config = ViTConfig(
@@ -99,7 +97,6 @@ class TestTransposedConv2dHeadConfig:
 
 
 class TestHead:
-
     @pytest.mark.parametrize("in_features", [64, 128])
     @pytest.mark.parametrize("out_features", [32, 128])
     def test_forward(self, device, in_features, out_features):
@@ -133,7 +130,6 @@ class TestHead:
 
 
 class TestTransposedConv2dHead:
-
     @pytest.mark.parametrize("in_channels", [64, 128])
     @pytest.mark.parametrize("out_channels", [32, 64])
     def test_forward(self, device, in_channels, out_channels):
@@ -231,7 +227,6 @@ class TestTransposedConv2dHead:
 
 
 class TestUpsampleHeadConfig:
-
     def test_instantiate(self):
         config = UpsampleHeadConfig(out_features=32, num_upsample_stages=4)
         vit_config = ViTConfig(
@@ -270,7 +265,6 @@ class TestUpsampleHeadConfig:
 
 
 class TestUpsampleHead:
-
     @pytest.mark.parametrize("in_channels", [64, 128])
     @pytest.mark.parametrize("out_channels", [32, 64])
     def test_forward(self, device, in_channels, out_channels):

--- a/tests/test_patch_embed.py
+++ b/tests/test_patch_embed.py
@@ -7,7 +7,6 @@ from vit.patch_embed import PatchEmbed2d, PatchEmbed3d
 
 
 class TestPatchEmbed2d:
-
     @pytest.mark.parametrize("pos_enc", ["fourier", "learnable", "none"])
     def test_forward(self, device, pos_enc):
         B, C, H, W = 2, 3, 64, 64
@@ -31,7 +30,6 @@ class TestPatchEmbed2d:
 
 
 class TestPatchEmbed3d:
-
     @pytest.mark.parametrize("pos_enc", ["fourier", "learnable", "none"])
     def test_forward(self, device, pos_enc):
         B, C, D, H, W = 2, 3, 4, 64, 64

--- a/tests/test_pos_enc.py
+++ b/tests/test_pos_enc.py
@@ -6,7 +6,6 @@ from vit.pos_enc import FourierPosition, LearnablePosition, create_grid
 
 
 class TestLearnablePosition:
-
     @pytest.mark.parametrize("fourier_init", [True, False])
     def test_forward(self, device, fourier_init):
         D = 16
@@ -60,7 +59,6 @@ class TestLearnablePosition:
 
 
 class TestFourierPosition:
-
     def test_forward(self, device):
         D = 16
         torch.random.manual_seed(0)

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -6,7 +6,6 @@ from vit.rope import RopePositionEmbedding
 
 
 class TestRopePositionEmbedding:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     def test_forward_basic(self, device, dtype):
         """Test basic forward pass without augmentations."""

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -57,7 +57,6 @@ def test_unapply():
 
 
 class TestCreateMask:
-
     @pytest.mark.parametrize(
         "size, exp",
         [

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -6,7 +6,6 @@ from vit.transformer import CrossAttentionTransformer, TransformerDecoderLayer, 
 
 
 class TestTransformerEncoderLayer:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     @pytest.mark.parametrize("layer_scale", [None, 1e-5])
     def test_forward(self, dtype, device, layer_scale):
@@ -47,7 +46,6 @@ class TestTransformerEncoderLayer:
 
 
 class TestTransformerDecoderLayer:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     @pytest.mark.parametrize("layer_scale", [None, 1e-5])
     def test_forward(self, dtype, device, layer_scale):
@@ -91,7 +89,6 @@ class TestTransformerDecoderLayer:
 
 
 class TestCrossAttentionTransformer:
-
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     @pytest.mark.parametrize("layer_scale", [None, 1e-5])
     def test_forward(self, dtype, device, layer_scale):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from vit import __version__
 from vit._version import __version__ as __version__2
 

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -41,7 +41,6 @@ def assert_none_requires_grad(module: Any):
 
 
 class TestViT:
-
     def test_default_dtype_is_bfloat16(self):
         """Verify that the default master weight dtype is BF16."""
         config = ViTConfig(
@@ -122,9 +121,9 @@ class TestViT:
             head = model.heads[head_name]
             for name, param in head.named_parameters():
                 assert param.dtype == dtype, f"Head {head_name} param {name} has dtype {param.dtype}, expected {dtype}"
-                assert (
-                    param.device == device
-                ), f"Head {head_name} param {name} on device {param.device}, expected {device}"
+                assert param.device == device, (
+                    f"Head {head_name} param {name} on device {param.device}, expected {device}"
+                )
 
     def test_config_from_yaml_str(self, config):
         config_str = config.to_yaml()
@@ -322,7 +321,6 @@ class TestViT:
 
 
 class TestViTFeatures:
-
     def test_iter(self):
         num_cls_tokens = 1
         num_register_tokens = 2
@@ -341,7 +339,7 @@ class TestViTFeatures:
 
     def test_repr(self):
         features = ViTFeatures(torch.randn(2, 33, 128), 0, 1)
-        expected = f"ViTFeatures(cls_tokens=(2, 1, 128), register_tokens=(2, 0, 128), visual_tokens=(2, 32, 128))"
+        expected = "ViTFeatures(cls_tokens=(2, 1, 128), register_tokens=(2, 0, 128), visual_tokens=(2, 32, 128))"
         assert isinstance(repr(features), str)
         assert repr(features) == expected
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,76 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "autoflake"
-version = "2.3.1"
+name = "basedpyright"
+version = "1.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyflakes" },
+    { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/cb/486f912d6171bc5748c311a2984a301f4e2d054833a1da78485866c71522/autoflake-2.3.1.tar.gz", hash = "sha256:c98b75dc5b0a86459c4f01a1d32ac7eb4338ec4317a4469515ff1e687ecd909e", size = 27642, upload-time = "2024-03-13T03:41:28.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/8a/4c5d74314fe085f8f9b1a92b7c96e2a116651b6c7596e4def872d5d7abf0/basedpyright-1.36.2.tar.gz", hash = "sha256:b596b1a6e6006c7dfd483efc1d602574f238321e28f70bc66e87255784b70630", size = 22835798, upload-time = "2025-12-23T02:31:27.357Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/ee/3fd29bf416eb4f1c5579cf12bf393ae954099258abd7bde03c4f9716ef6b/autoflake-2.3.1-py3-none-any.whl", hash = "sha256:3ae7495db9084b7b32818b4140e6dc4fc280b712fb414f5b8fe57b0a8e85a840", size = 32483, upload-time = "2024-03-13T03:41:26.969Z" },
-]
-
-[[package]]
-name = "autopep8"
-version = "2.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycodestyle" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
-]
-
-[[package]]
-name = "black"
-version = "25.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/d9/07b458a3f1c525ac392b5edc6b191ff140b596f9d77092429417a54e249d/black-25.12.0.tar.gz", hash = "sha256:8d3dd9cea14bff7ddc0eb243c811cdb1a011ebb4800a5f0335a01a68654796a7", size = 659264, upload-time = "2025-12-08T01:40:52.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/ad/7ac0d0e1e0612788dbc48e62aef8a8e8feffac7eb3d787db4e43b8462fa8/black-25.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d0cfa263e85caea2cff57d8f917f9f51adae8e20b610e2b23de35b5b11ce691a", size = 1877003, upload-time = "2025-12-08T01:43:29.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/dd/a237e9f565f3617a88b49284b59cbca2a4f56ebe68676c1aad0ce36a54a7/black-25.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a2f578ae20c19c50a382286ba78bfbeafdf788579b053d8e4980afb079ab9be", size = 1712639, upload-time = "2025-12-08T01:52:46.756Z" },
-    { url = "https://files.pythonhosted.org/packages/12/80/e187079df1ea4c12a0c63282ddd8b81d5107db6d642f7d7b75a6bcd6fc21/black-25.12.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e1b65634b0e471d07ff86ec338819e2ef860689859ef4501ab7ac290431f9b", size = 1758143, upload-time = "2025-12-08T01:45:29.137Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b5/3096ccee4f29dc2c3aac57274326c4d2d929a77e629f695f544e159bfae4/black-25.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a3fa71e3b8dd9f7c6ac4d818345237dfb4175ed3bf37cd5a581dbc4c034f1ec5", size = 1420698, upload-time = "2025-12-08T01:45:53.379Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/39/f81c0ffbc25ffbe61c7d0385bf277e62ffc3e52f5ee668d7369d9854fadf/black-25.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:51e267458f7e650afed8445dc7edb3187143003d52a1b710c7321aef22aa9655", size = 1229317, upload-time = "2025-12-08T01:46:35.606Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/bd/26083f805115db17fda9877b3c7321d08c647df39d0df4c4ca8f8450593e/black-25.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:31f96b7c98c1ddaeb07dc0f56c652e25bdedaac76d5b68a059d998b57c55594a", size = 1924178, upload-time = "2025-12-08T01:49:51.048Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6b/ea00d6651561e2bdd9231c4177f4f2ae19cc13a0b0574f47602a7519b6ca/black-25.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:05dd459a19e218078a1f98178c13f861fe6a9a5f88fc969ca4d9b49eb1809783", size = 1742643, upload-time = "2025-12-08T01:49:59.09Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f3/360fa4182e36e9875fabcf3a9717db9d27a8d11870f21cff97725c54f35b/black-25.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1f68c5eff61f226934be6b5b80296cf6939e5d2f0c2f7d543ea08b204bfaf59", size = 1800158, upload-time = "2025-12-08T01:44:27.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/08/2c64830cb6616278067e040acca21d4f79727b23077633953081c9445d61/black-25.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:274f940c147ddab4442d316b27f9e332ca586d39c85ecf59ebdea82cc9ee8892", size = 1426197, upload-time = "2025-12-08T01:45:51.198Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/60/a93f55fd9b9816b7432cf6842f0e3000fdd5b7869492a04b9011a133ee37/black-25.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:169506ba91ef21e2e0591563deda7f00030cb466e747c4b09cb0a9dae5db2f43", size = 1237266, upload-time = "2025-12-08T01:45:10.556Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/52/c551e36bc95495d2aa1a37d50566267aa47608c81a53f91daa809e03293f/black-25.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a05ddeb656534c3e27a05a29196c962877c83fa5503db89e68857d1161ad08a5", size = 1923809, upload-time = "2025-12-08T01:46:55.126Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f7/aac9b014140ee56d247e707af8db0aae2e9efc28d4a8aba92d0abd7ae9d1/black-25.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9ec77439ef3e34896995503865a85732c94396edcc739f302c5673a2315e1e7f", size = 1742384, upload-time = "2025-12-08T01:49:37.022Z" },
-    { url = "https://files.pythonhosted.org/packages/74/98/38aaa018b2ab06a863974c12b14a6266badc192b20603a81b738c47e902e/black-25.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e509c858adf63aa61d908061b52e580c40eae0dfa72415fa47ac01b12e29baf", size = 1798761, upload-time = "2025-12-08T01:46:05.386Z" },
-    { url = "https://files.pythonhosted.org/packages/16/3a/a8ac542125f61574a3f015b521ca83b47321ed19bb63fe6d7560f348bfe1/black-25.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:252678f07f5bac4ff0d0e9b261fbb029fa530cfa206d0a636a34ab445ef8ca9d", size = 1429180, upload-time = "2025-12-08T01:45:34.903Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/2d/bdc466a3db9145e946762d52cd55b1385509d9f9004fec1c97bdc8debbfb/black-25.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:bc5b1c09fe3c931ddd20ee548511c64ebf964ada7e6f0763d443947fd1c603ce", size = 1239350, upload-time = "2025-12-08T01:46:09.458Z" },
-    { url = "https://files.pythonhosted.org/packages/35/46/1d8f2542210c502e2ae1060b2e09e47af6a5e5963cb78e22ec1a11170b28/black-25.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0a0953b134f9335c2434864a643c842c44fba562155c738a2a37a4d61f00cad5", size = 1917015, upload-time = "2025-12-08T01:53:27.987Z" },
-    { url = "https://files.pythonhosted.org/packages/41/37/68accadf977672beb8e2c64e080f568c74159c1aaa6414b4cd2aef2d7906/black-25.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2355bbb6c3b76062870942d8cc450d4f8ac71f9c93c40122762c8784df49543f", size = 1741830, upload-time = "2025-12-08T01:54:36.861Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/76/03608a9d8f0faad47a3af3a3c8c53af3367f6c0dd2d23a84710456c7ac56/black-25.12.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9678bd991cc793e81d19aeeae57966ee02909877cb65838ccffef24c3ebac08f", size = 1791450, upload-time = "2025-12-08T01:44:52.581Z" },
-    { url = "https://files.pythonhosted.org/packages/06/99/b2a4bd7dfaea7964974f947e1c76d6886d65fe5d24f687df2d85406b2609/black-25.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:97596189949a8aad13ad12fcbb4ae89330039b96ad6742e6f6b45e75ad5cfd83", size = 1452042, upload-time = "2025-12-08T01:46:13.188Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/7c/d9825de75ae5dd7795d007681b752275ea85a1c5d83269b4b9c754c2aaab/black-25.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:778285d9ea197f34704e3791ea9404cd6d07595745907dd2ce3da7a13627b29b", size = 1267446, upload-time = "2025-12-08T01:46:14.497Z" },
-    { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/69/88/0aaac8e5062cd83434ce41fac844646d0f285b574cda0eeb732e916db22b/basedpyright-1.36.2-py3-none-any.whl", hash = "sha256:8dfd74fad77fcccc066ea0af5fd07e920b6f88cb1b403936aa78ab5aaef51526", size = 11882631, upload-time = "2025-12-23T02:31:24.537Z" },
 ]
 
 [[package]]
@@ -294,20 +233,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.61.0"
 source = { registry = "https://pypi.org/simple" }
@@ -372,15 +297,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "isort"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
 ]
 
 [[package]]
@@ -624,30 +540,12 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -660,12 +558,19 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
+name = "nodejs-wheel-binaries"
+version = "24.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/35/d806c2ca66072e36dc340ccdbeb2af7e4f1b5bcc33f1481f00ceed476708/nodejs_wheel_binaries-24.12.0.tar.gz", hash = "sha256:f1b50aa25375e264697dec04b232474906b997c2630c8f499f4caf3692938435", size = 8058, upload-time = "2025-12-11T21:12:26.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/3b/9d6f044319cd5b1e98f07c41e2465b58cadc1c9c04a74c891578f3be6cb5/nodejs_wheel_binaries-24.12.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:7564ddea0a87eff34e9b3ef71764cc2a476a8f09a5cccfddc4691148b0a47338", size = 55125859, upload-time = "2025-12-11T21:11:58.132Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a5/f5722bf15c014e2f476d7c76bce3d55c341d19122d8a5d86454db32a61a4/nodejs_wheel_binaries-24.12.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:8ff929c4669e64613ceb07f5bbd758d528c3563820c75d5de3249eb452c0c0ab", size = 55309035, upload-time = "2025-12-11T21:12:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/61/68d39a6f1b5df67805969fd2829ba7e80696c9af19537856ec912050a2be/nodejs_wheel_binaries-24.12.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:6ebacefa8891bc456ad3655e6bce0af7e20ba08662f79d9109986faeb703fd6f", size = 59661017, upload-time = "2025-12-11T21:12:05.268Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a1/31aad16f55a5e44ca7ea62d1367fc69f4b6e1dba67f58a0a41d0ed854540/nodejs_wheel_binaries-24.12.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3292649a03682ccbfa47f7b04d3e4240e8c46ef04dc941b708f20e4e6a764f75", size = 60159770, upload-time = "2025-12-11T21:12:08.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5e/b7c569aa1862690ca4d4daf3a64cafa1ea6ce667a9e3ae3918c56e127d9b/nodejs_wheel_binaries-24.12.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7fb83df312955ea355ba7f8cbd7055c477249a131d3cb43b60e4aeb8f8c730b1", size = 61653561, upload-time = "2025-12-11T21:12:12.575Z" },
+    { url = "https://files.pythonhosted.org/packages/71/87/567f58d7ba69ff0208be849b37be0f2c2e99c69e49334edd45ff44f00043/nodejs_wheel_binaries-24.12.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2473c819448fedd7b036dde236b09f3c8bbf39fbbd0c1068790a0498800f498b", size = 62238331, upload-time = "2025-12-11T21:12:16.143Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9d/c6492188ce8de90093c6755a4a63bb6b2b4efb17094cb4f9a9a49c73ed3b/nodejs_wheel_binaries-24.12.0-py2.py3-none-win_amd64.whl", hash = "sha256:2090d59f75a68079fabc9b86b14df8238b9aecb9577966dc142ce2a23a32e9bb", size = 41342076, upload-time = "2025-12-11T21:12:20.618Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/cd3290a647df567645353feed451ef4feaf5844496ced69c4dcb84295ff4/nodejs_wheel_binaries-24.12.0-py2.py3-none-win_arm64.whl", hash = "sha256:d0c2273b667dd7e3f55e369c0085957b702144b1b04bfceb7ce2411e58333757", size = 39048104, upload-time = "2025-12-11T21:12:23.495Z" },
 ]
 
 [[package]]
@@ -893,15 +798,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
 name = "pdbpp"
 version = "0.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1002,39 +898,12 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -1071,19 +940,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/4f/7088417e5465c53a30b918d30542aad89352ea0d635a5d077717c69a7d2b/pyrepl-0.11.4.tar.gz", hash = "sha256:efe988b4a6e5eed587e9769dc2269aeec2b6feec2f5d77995ee85b9ad7cf7063", size = 51089, upload-time = "2025-07-17T22:56:25.42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/a5/ce97a778f096aaa27cfcb7ad09f1198cf73277dcab6c68a4b8f332d91e48/pyrepl-0.11.4-py3-none-any.whl", hash = "sha256:ac30d6340267a21c39e1b1934f92bca6b8735017d14b17e40f903b2d1563541d", size = 55596, upload-time = "2025-07-17T22:56:24.537Z" },
-]
-
-[[package]]
-name = "pyright"
-version = "1.1.407"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/1b/0aa08ee42948b61745ac5b5b5ccaec4669e8884b53d31c8ec20b2fcd6b6f/pyright-1.1.407.tar.gz", hash = "sha256:099674dba5c10489832d4a4b2d302636152a9a42d317986c38474c76fe562262", size = 4122872, upload-time = "2025-10-24T23:17:15.145Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/93/b69052907d032b00c40cb656d21438ec00b3a471733de137a3f65a49a0a0/pyright-1.1.407-py3-none-any.whl", hash = "sha256:6dd419f54fcc13f03b52285796d65e639786373f433e243f8b94cf93a7444d21", size = 5997008, upload-time = "2025-10-24T23:17:13.159Z" },
 ]
 
 [[package]]
@@ -1153,15 +1009,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytokens"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1214,6 +1061,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/08/52232a877978dd8f9cf2aeddce3e611b40a63287dfca29b6b8da791f5e8d/ruff-0.14.10.tar.gz", hash = "sha256:9a2e830f075d1a42cd28420d7809ace390832a490ed0966fe373ba288e77aaf4", size = 5859763, upload-time = "2025-12-18T19:28:57.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/01/933704d69f3f05ee16ef11406b78881733c186fe14b6a46b05cfcaf6d3b2/ruff-0.14.10-py3-none-linux_armv6l.whl", hash = "sha256:7a3ce585f2ade3e1f29ec1b92df13e3da262178df8c8bdf876f48fa0e8316c49", size = 13527080, upload-time = "2025-12-18T19:29:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/a0349197a7dfa603ffb7f5b0470391efa79ddc327c1e29c4851e85b09cc5/ruff-0.14.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:674f9be9372907f7257c51f1d4fc902cb7cf014b9980152b802794317941f08f", size = 13797320, upload-time = "2025-12-18T19:29:02.571Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/82/36be59f00a6082e38c23536df4e71cdbc6af8d7c707eade97fcad5c98235/ruff-0.14.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d85713d522348837ef9df8efca33ccb8bd6fcfc86a2cde3ccb4bc9d28a18003d", size = 12918434, upload-time = "2025-12-18T19:28:51.202Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/00/45c62a7f7e34da92a25804f813ebe05c88aa9e0c25e5cb5a7d23dd7450e3/ruff-0.14.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6987ebe0501ae4f4308d7d24e2d0fe3d7a98430f5adfd0f1fead050a740a3a77", size = 13371961, upload-time = "2025-12-18T19:29:04.991Z" },
+    { url = "https://files.pythonhosted.org/packages/40/31/a5906d60f0405f7e57045a70f2d57084a93ca7425f22e1d66904769d1628/ruff-0.14.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:16a01dfb7b9e4eee556fbfd5392806b1b8550c9b4a9f6acd3dbe6812b193c70a", size = 13275629, upload-time = "2025-12-18T19:29:21.381Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/60/61c0087df21894cf9d928dc04bcd4fb10e8b2e8dca7b1a276ba2155b2002/ruff-0.14.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7165d31a925b7a294465fa81be8c12a0e9b60fb02bf177e79067c867e71f8b1f", size = 14029234, upload-time = "2025-12-18T19:29:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/44/84/77d911bee3b92348b6e5dab5a0c898d87084ea03ac5dc708f46d88407def/ruff-0.14.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c561695675b972effb0c0a45db233f2c816ff3da8dcfbe7dfc7eed625f218935", size = 15449890, upload-time = "2025-12-18T19:28:53.573Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/36/480206eaefa24a7ec321582dda580443a8f0671fdbf6b1c80e9c3e93a16a/ruff-0.14.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4bb98fcbbc61725968893682fd4df8966a34611239c9fd07a1f6a07e7103d08e", size = 15123172, upload-time = "2025-12-18T19:29:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/38/68e414156015ba80cef5473d57919d27dfb62ec804b96180bafdeaf0e090/ruff-0.14.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f24b47993a9d8cb858429e97bdf8544c78029f09b520af615c1d261bf827001d", size = 14460260, upload-time = "2025-12-18T19:29:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/19/9e050c0dca8aba824d67cc0db69fb459c28d8cd3f6855b1405b3f29cc91d/ruff-0.14.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59aabd2e2c4fd614d2862e7939c34a532c04f1084476d6833dddef4afab87e9f", size = 14229978, upload-time = "2025-12-18T19:29:11.32Z" },
+    { url = "https://files.pythonhosted.org/packages/51/eb/e8dd1dd6e05b9e695aa9dd420f4577debdd0f87a5ff2fedda33c09e9be8c/ruff-0.14.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:213db2b2e44be8625002dbea33bb9c60c66ea2c07c084a00d55732689d697a7f", size = 14338036, upload-time = "2025-12-18T19:29:09.184Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/12/f3e3a505db7c19303b70af370d137795fcfec136d670d5de5391e295c134/ruff-0.14.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b914c40ab64865a17a9a5b67911d14df72346a634527240039eb3bd650e5979d", size = 13264051, upload-time = "2025-12-18T19:29:13.431Z" },
+    { url = "https://files.pythonhosted.org/packages/08/64/8c3a47eaccfef8ac20e0484e68e0772013eb85802f8a9f7603ca751eb166/ruff-0.14.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1484983559f026788e3a5c07c81ef7d1e97c1c78ed03041a18f75df104c45405", size = 13283998, upload-time = "2025-12-18T19:29:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/12/84/534a5506f4074e5cc0529e5cd96cfc01bb480e460c7edf5af70d2bcae55e/ruff-0.14.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c70427132db492d25f982fffc8d6c7535cc2fd2c83fc8888f05caaa248521e60", size = 13601891, upload-time = "2025-12-18T19:28:55.811Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/14c916087d8598917dbad9b2921d340f7884824ad6e9c55de948a93b106d/ruff-0.14.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5bcf45b681e9f1ee6445d317ce1fa9d6cba9a6049542d1c3d5b5958986be8830", size = 14336660, upload-time = "2025-12-18T19:29:16.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
+    { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
 ]
 
 [[package]]
@@ -1410,19 +1283,15 @@ benchmarking = [
     { name = "tqdm" },
 ]
 dev = [
-    { name = "autoflake" },
-    { name = "autopep8" },
-    { name = "black" },
+    { name = "basedpyright" },
     { name = "coverage" },
-    { name = "flake8" },
-    { name = "isort" },
     { name = "matplotlib" },
     { name = "pdbpp" },
-    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mock" },
+    { name = "ruff" },
     { name = "tqdm" },
 ]
 
@@ -1440,18 +1309,14 @@ benchmarking = [
     { name = "tqdm" },
 ]
 dev = [
-    { name = "autoflake" },
-    { name = "autopep8" },
-    { name = "black" },
+    { name = "basedpyright" },
     { name = "coverage" },
-    { name = "flake8" },
-    { name = "isort" },
     { name = "matplotlib" },
     { name = "pdbpp" },
-    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mock" },
+    { name = "ruff" },
     { name = "tqdm" },
 ]

--- a/vit/__init__.py
+++ b/vit/__init__.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import importlib.metadata
 
-from .head import Head, HeadConfig, TransposedConv2dHead, TransposedConv2dHeadConfig, UpsampleHead, UpsampleHeadConfig
-from .head import register_constructors as register_head_constructors
-from .vit import ViT, ViTConfig, ViTFeatures
-from .vit import register_constructors as register_vit_constructors
+from .head import (
+    Head,
+    HeadConfig,
+    TransposedConv2dHead,
+    TransposedConv2dHeadConfig,
+    UpsampleHead,
+    UpsampleHeadConfig,
+    register_constructors as register_head_constructors,
+)
+from .vit import ViT, ViTConfig, ViTFeatures, register_constructors as register_vit_constructors
 
 
 register_vit_constructors()

--- a/vit/fused.py
+++ b/vit/fused.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -13,7 +14,8 @@ from .helpers import get_activation
 def norm_linear(
     # fmt: off
     x: Tensor,
-    weight: Tensor, bias: Tensor | None,
+    weight: Tensor,
+    bias: Tensor | None,
     norm_weight: Tensor,
     eps: float,
     dropout: float,
@@ -26,7 +28,6 @@ def norm_linear(
 
 
 class NormLinear(nn.Module):
-
     def __init__(
         self,
         in_features: int,
@@ -87,8 +88,10 @@ class NormLinear(nn.Module):
 def norm_mlp(
     # fmt: off
     x: Tensor,
-    fc1_weight: Tensor, fc1_bias: Tensor | None,
-    fc2_weight: Tensor, fc2_bias: Tensor | None,
+    fc1_weight: Tensor,
+    fc1_bias: Tensor | None,
+    fc2_weight: Tensor,
+    fc2_bias: Tensor | None,
     norm_weight: Tensor | None,
     activation: Callable[[Tensor], Tensor],
     eps: float,
@@ -118,8 +121,10 @@ def norm_mlp(
 def norm_mlp_glu(
     # fmt: off
     x: Tensor,
-    fc1_weight: Tensor, fc1_bias: Tensor | None,
-    fc2_weight: Tensor, fc2_bias: Tensor | None,
+    fc1_weight: Tensor,
+    fc1_bias: Tensor | None,
+    fc2_weight: Tensor,
+    fc2_bias: Tensor | None,
     norm_weight: Tensor | None,
     activation: Callable[[Tensor], Tensor],
     eps: float,
@@ -150,7 +155,6 @@ def norm_mlp_glu(
 
 
 class NormMLP(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
@@ -201,8 +205,10 @@ class NormMLP(nn.Module):
             return norm_mlp_glu(
                 # fmt: off
                 x,
-                self.fc1.weight, self.fc1.bias,
-                self.fc2.weight, self.fc2.bias,
+                self.fc1.weight,
+                self.fc1.bias,
+                self.fc2.weight,
+                self.fc2.bias,
                 self.norm.weight,
                 self.activation,
                 self.norm.eps or 1e-5,
@@ -216,8 +222,10 @@ class NormMLP(nn.Module):
             return norm_mlp(
                 # fmt: off
                 x,
-                self.fc1.weight, self.fc1.bias,
-                self.fc2.weight, self.fc2.bias,
+                self.fc1.weight,
+                self.fc1.bias,
+                self.fc2.weight,
+                self.fc2.bias,
                 self.norm.weight,
                 self.activation,
                 self.norm.eps or 1e-5,

--- a/vit/head.py
+++ b/vit/head.py
@@ -124,7 +124,6 @@ class TransposedConv2dHeadConfig:
 
 
 class Head(nn.Module):
-
     def __init__(
         self,
         in_features: int,

--- a/vit/helpers.py
+++ b/vit/helpers.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn

--- a/vit/patch_embed.py
+++ b/vit/patch_embed.py
@@ -1,4 +1,5 @@
-from typing import Any, Sequence, Tuple, cast
+from collections.abc import Sequence
+from typing import Any, cast
 
 import torch
 import torch.nn as nn
@@ -8,7 +9,6 @@ from .pos_enc import PositionEncoder, create_position_encoder
 
 
 class PatchEmbed2d(nn.Module):
-
     def __init__(
         self,
         in_channels: int,
@@ -33,14 +33,14 @@ class PatchEmbed2d(nn.Module):
         )
 
     @property
-    def patch_size(self) -> Tuple[int, int]:
-        return cast(Tuple[int, int], tuple(self.patch.weight.shape[2:]))
+    def patch_size(self) -> tuple[int, int]:
+        return cast(tuple[int, int], tuple(self.patch.weight.shape[2:]))
 
-    def tokenized_size(self, size: Sequence[int]) -> Tuple[int, int]:
+    def tokenized_size(self, size: Sequence[int]) -> tuple[int, int]:
         ht, wt = tuple(s // p for s, p in zip(size, self.patch_size))
         return ht, wt
 
-    def original_size(self, size: Tuple[int, int]) -> Tuple[int, int]:
+    def original_size(self, size: tuple[int, int]) -> tuple[int, int]:
         ht, wt = tuple(s * p for s, p in zip(size, self.patch_size))
         return ht, wt
 
@@ -55,7 +55,6 @@ class PatchEmbed2d(nn.Module):
 
 
 class PatchEmbed3d(nn.Module):
-
     def __init__(
         self,
         in_channels: int,
@@ -80,14 +79,14 @@ class PatchEmbed3d(nn.Module):
         )
 
     @property
-    def patch_size(self) -> Tuple[int, int, int]:
-        return cast(Tuple[int, int, int], tuple(self.patch.weight.shape[2:]))
+    def patch_size(self) -> tuple[int, int, int]:
+        return cast(tuple[int, int, int], tuple(self.patch.weight.shape[2:]))
 
-    def tokenized_size(self, size: Sequence[int]) -> Tuple[int, int, int]:
+    def tokenized_size(self, size: Sequence[int]) -> tuple[int, int, int]:
         dt, ht, wt = tuple(s // p for s, p in zip(size, self.patch_size))
         return dt, ht, wt
 
-    def original_size(self, size: Sequence[int]) -> Tuple[int, int, int]:
+    def original_size(self, size: Sequence[int]) -> tuple[int, int, int]:
         dt, ht, wt = tuple(s * p for s, p in zip(size, self.patch_size))
         return dt, ht, wt
 

--- a/vit/pos_enc.py
+++ b/vit/pos_enc.py
@@ -1,5 +1,6 @@
 import math
-from typing import TYPE_CHECKING, Literal, Sequence, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal, Union
 
 import torch
 import torch.nn as nn
@@ -88,7 +89,6 @@ def learnable_position(
 
 
 class LearnablePosition(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
@@ -148,7 +148,6 @@ def fourier_position(
 
 
 class FourierPosition(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,

--- a/vit/tokens.py
+++ b/vit/tokens.py
@@ -1,4 +1,5 @@
-from typing import Sequence, cast
+from collections.abc import Sequence
+from typing import cast
 
 import torch
 import torch.nn.functional as F

--- a/vit/transformer.py
+++ b/vit/transformer.py
@@ -11,7 +11,6 @@ from .layer_scale import LayerScale
 
 
 class TransformerEncoderLayer(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
@@ -97,7 +96,6 @@ class TransformerEncoderLayer(nn.Module):
 
 
 class TransformerDecoderLayer(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
@@ -203,7 +201,6 @@ class TransformerDecoderLayer(nn.Module):
 
 
 class CrossAttentionTransformer(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,


### PR DESCRIPTION
Replace autopep8, black, isort, autoflake, flake8, and pyright with ruff and basedpyright. This consolidates multiple tools into a faster, unified setup.

- Update pyproject.toml with new tool configs and dependencies
- Update Makefile recipes to use ruff and basedpyright
- Add .ruff_cache to .gitignore
- Apply ruff auto-fixes and formatting to codebase
- Update CLAUDE.md documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)