### PR TITLE
Add AdaNorm support through MLP, transformer, and ViT

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ import torch
 import torch._dynamo
 import torch._dynamo.config
 
-from vit.fused import AdaNormMLP
-
 
 # Disable torch.compile by default for faster tests
 # The env var signals our intent, the config flag actually disables compilation
@@ -49,20 +47,6 @@ def handle_cuda_mark(item):  # pragma: no cover
 
 def pytest_runtest_setup(item):
     handle_cuda_mark(item)
-
-
-def enable_adaln_gate(module: AdaNormMLP) -> None:
-    with torch.no_grad():
-        assert module.modulation.bias is not None
-        hidden_size = module.fc2.out_features
-        module.modulation.bias[2 * hidden_size :].fill_(1.0)
-
-
-def enable_model_adaln_gates(model) -> None:
-    with torch.no_grad():
-        for block in model.blocks:
-            assert isinstance(block.mlp, AdaNormMLP)
-            enable_adaln_gate(block.mlp)
 
 
 @pytest.fixture(params=["cpu", "cuda:0"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import torch
 import torch._dynamo
 import torch._dynamo.config
 
+from vit.fused import AdaNormMLP
+
 
 # Disable torch.compile by default for faster tests
 # The env var signals our intent, the config flag actually disables compilation
@@ -47,6 +49,20 @@ def handle_cuda_mark(item):  # pragma: no cover
 
 def pytest_runtest_setup(item):
     handle_cuda_mark(item)
+
+
+def enable_adaln_gate(module: AdaNormMLP) -> None:
+    with torch.no_grad():
+        assert module.modulation.bias is not None
+        hidden_size = module.fc2.out_features
+        module.modulation.bias[2 * hidden_size :].fill_(1.0)
+
+
+def enable_model_adaln_gates(model) -> None:
+    with torch.no_grad():
+        for block in model.blocks:
+            assert isinstance(block.mlp, AdaNormMLP)
+            enable_adaln_gate(block.mlp)
 
 
 @pytest.fixture(params=["cpu", "cuda:0"])

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 
 import pytest
 import torch
+from conftest import enable_model_adaln_gates
 from torch.testing import assert_close
 
 from vit.vit import ViT, ViTConfig
@@ -157,6 +158,21 @@ class TestActivationCheckpointing:
             if param.requires_grad:
                 assert param.grad is not None, f"{name} has no gradient with mask"
                 assert not param.grad.isnan().any(), f"{name} has nan gradient with mask"
+
+    def test_checkpointing_with_conditioning(self, device, config):
+        config = replace(config, activation_checkpointing=True, conditioning_size=32)
+        model = ViT(config).to(device)
+        enable_model_adaln_gates(model)
+        model.train()
+        x = torch.randn(2, 3, 224, 224, device=device, requires_grad=True)
+        conditioning = torch.randn(2, 32, device=device)
+        out = model(x, conditioning=conditioning)
+        out.dense_features.sum().backward()
+
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                assert param.grad is not None, f"{name} has no gradient with conditioning"
+                assert not param.grad.isnan().any(), f"{name} has nan gradient with conditioning"
 
     def test_checkpointing_with_drop_path(self, device, config):
         """Verify checkpointing handles stochastic depth correctly."""

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -3,7 +3,6 @@ from dataclasses import replace
 
 import pytest
 import torch
-from conftest import enable_model_adaln_gates
 from torch.testing import assert_close
 
 from vit.vit import ViT, ViTConfig
@@ -162,7 +161,6 @@ class TestActivationCheckpointing:
     def test_checkpointing_with_conditioning(self, device, config):
         config = replace(config, activation_checkpointing=True, conditioning_size=32)
         model = ViT(config).to(device)
-        enable_model_adaln_gates(model)
         model.train()
         x = torch.randn(2, 3, 224, 224, device=device, requires_grad=True)
         conditioning = torch.randn(2, 32, device=device)

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -2,11 +2,40 @@ from copy import deepcopy
 
 import pytest
 import torch
+import torch.nn.functional as F
 from torch.testing import assert_close
 from torchao.dtypes import AffineQuantizedTensor
 from torchao.quantization import Int8WeightOnlyConfig
 
-from vit.fused import NormLinear, NormMLP
+from vit.fused import AdaNormMLP, NormLinear, NormMLP
+
+
+def _apply_norm_manual(
+    x: torch.Tensor,
+    norm: torch.nn.LayerNorm | torch.nn.RMSNorm,
+    *,
+    scale_delta: torch.Tensor | None = None,
+    shift: torch.Tensor | None = None,
+) -> torch.Tensor:
+    bias = norm.bias if isinstance(norm, torch.nn.LayerNorm) else None
+    if isinstance(norm, torch.nn.LayerNorm):
+        x = F.layer_norm(x, x.shape[-1:], norm.weight, None, norm.eps)
+    else:
+        x = F.rms_norm(x, x.shape[-1:], norm.weight, norm.eps)
+    if scale_delta is not None:
+        x = x * (1 + scale_delta)
+    if bias is not None:
+        x = x + bias
+    if shift is not None:
+        x = x + shift
+    return x
+
+
+def _enable_adaln_gate(layer: AdaNormMLP) -> None:
+    with torch.no_grad():
+        assert layer.modulation.bias is not None
+        hidden_size = layer.fc2.out_features
+        layer.modulation.bias[2 * hidden_size :].fill_(1.0)
 
 
 class TestNormLinear:
@@ -108,6 +137,33 @@ class TestNormMLP:
             assert param.grad is not None
             assert not param.grad.isnan().any()
 
+    def test_forward_with_explicit_none_matches_default(self, device):
+        layer = NormMLP(10, 20, activation="relu", dropout=0.0).to(device)
+        layer.eval()
+        x = torch.randn(2, 4, 10, device=device)
+
+        y_default = layer(x)
+        y_none = layer(x, norm_scale_delta=None, norm_shift=None, output_gate=None)
+        assert_close(y_default, y_none)
+
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_forward_with_modulation_matches_manual_reference(self, device, norm_type):
+        layer = NormMLP(10, 20, activation="relu", dropout=0.0, norm_type=norm_type).to(device)
+        layer.eval()
+        x = torch.randn(2, 4, 10, device=device)
+        norm_scale_delta = torch.randn(2, 1, 10, device=device)
+        norm_shift = torch.randn(2, 1, 10, device=device)
+        output_gate = torch.randn(2, 1, 10, device=device)
+
+        y = layer(x, norm_scale_delta=norm_scale_delta, norm_shift=norm_shift, output_gate=output_gate)
+
+        expected = _apply_norm_manual(x, layer.norm, scale_delta=norm_scale_delta, shift=norm_shift)
+        expected = F.linear(expected, layer.fc1.weight, layer.fc1.bias)
+        expected = layer.activation(expected)
+        expected = F.linear(expected, layer.fc2.weight, layer.fc2.bias)
+        expected = expected * output_gate
+        assert_close(y, expected)
+
     def test_quantization(self, device):
         torch.random.manual_seed(0)
         layer_norm_mlp = NormMLP(10, 20).to(device)
@@ -123,4 +179,58 @@ class TestNormMLP:
         with torch.autocast(device_type=device.type, dtype=torch.bfloat16, enabled=True):
             y = layer_norm_mlp(x)
             y_quant = quantized_layer_norm_mlp(x)
+        assert_close(y, y_quant, atol=1e-2, rtol=0)
+
+
+class TestAdaNormMLP:
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_zero_init_outputs_zero(self, device, norm_type):
+        layer = AdaNormMLP(10, 20, norm_type=norm_type).to(device)
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+
+        y = layer(x, conditioning=conditioning)
+        assert_close(y, torch.zeros_like(y))
+
+    @pytest.mark.parametrize("activation", ["relu", "swiglu"])
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_forward(self, device, activation, norm_type):
+        layer = AdaNormMLP(10, 20, activation=activation, norm_type=norm_type).to(device)
+        _enable_adaln_gate(layer)
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+        with torch.autocast(device_type=device.type, dtype=torch.float32, enabled=True):
+            y = layer(x, conditioning=conditioning)
+        assert y.shape == x.shape
+
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_backward(self, device, norm_type):
+        layer = AdaNormMLP(10, 20, norm_type=norm_type).to(device)
+        _enable_adaln_gate(layer)
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+        with torch.autocast(device_type=device.type, dtype=torch.float32, enabled=True):
+            y = layer(x, conditioning=conditioning)
+        y.sum().backward()
+        for param in layer.parameters():
+            assert param.grad is not None
+            assert not param.grad.isnan().any()
+
+    def test_quantization(self, device):
+        torch.random.manual_seed(0)
+        layer = AdaNormMLP(10, 20).to(device)
+        _enable_adaln_gate(layer)
+        layer.eval()
+        quantized_layer = deepcopy(layer)
+        quantized_layer.apply_quantization(Int8WeightOnlyConfig())
+        weight1 = quantized_layer.fc1.weight
+        weight2 = quantized_layer.fc2.weight
+        assert isinstance(weight1, AffineQuantizedTensor)
+        assert isinstance(weight2, AffineQuantizedTensor)
+
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+        with torch.autocast(device_type=device.type, dtype=torch.bfloat16, enabled=True):
+            y = layer(x, conditioning=conditioning)
+            y_quant = quantized_layer(x, conditioning=conditioning)
         assert_close(y, y_quant, atol=1e-2, rtol=0)

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -31,13 +31,6 @@ def _apply_norm_manual(
     return x
 
 
-def _enable_adaln_gate(layer: AdaNormMLP) -> None:
-    with torch.no_grad():
-        assert layer.modulation.bias is not None
-        hidden_size = layer.fc2.out_features
-        layer.modulation.bias[2 * hidden_size :].fill_(1.0)
-
-
 class TestNormLinear:
     def test_reset_parameters_zeros_bias(self):
         layer = NormLinear(10, 20)
@@ -196,7 +189,6 @@ class TestAdaNormMLP:
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
     def test_forward(self, device, activation, norm_type):
         layer = AdaNormMLP(10, 20, activation=activation, norm_type=norm_type).to(device)
-        _enable_adaln_gate(layer)
         x = torch.randn(2, 4, 10, device=device)
         conditioning = torch.randn(2, 10, device=device)
         with torch.autocast(device_type=device.type, dtype=torch.float32, enabled=True):
@@ -206,7 +198,6 @@ class TestAdaNormMLP:
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
     def test_backward(self, device, norm_type):
         layer = AdaNormMLP(10, 20, norm_type=norm_type).to(device)
-        _enable_adaln_gate(layer)
         x = torch.randn(2, 4, 10, device=device)
         conditioning = torch.randn(2, 10, device=device)
         with torch.autocast(device_type=device.type, dtype=torch.float32, enabled=True):
@@ -219,7 +210,6 @@ class TestAdaNormMLP:
     def test_quantization(self, device):
         torch.random.manual_seed(0)
         layer = AdaNormMLP(10, 20).to(device)
-        _enable_adaln_gate(layer)
         layer.eval()
         quantized_layer = deepcopy(layer)
         quantized_layer.apply_quantization(Int8WeightOnlyConfig())

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -7,7 +7,7 @@ from torch.testing import assert_close
 from torchao.dtypes import AffineQuantizedTensor
 from torchao.quantization import Int8WeightOnlyConfig
 
-from vit.fused import AdaNormMLP, NormLinear, NormMLP
+from vit.fused import VALID_ADALN_GATE_INITS, AdaNormMLP, NormLinear, NormMLP
 
 
 def _apply_norm_manual(
@@ -176,6 +176,10 @@ class TestNormMLP:
 
 
 class TestAdaNormMLP:
+    def test_invalid_adaln_gate_init_raises(self):
+        with pytest.raises(ValueError, match="adaln_gate_init must be one of"):
+            AdaNormMLP(10, 20, adaln_gate_init=0.5)
+
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
     def test_zero_init_outputs_zero(self, device, norm_type):
         layer = AdaNormMLP(10, 20, norm_type=norm_type).to(device)
@@ -184,6 +188,21 @@ class TestAdaNormMLP:
 
         y = layer(x, conditioning=conditioning)
         assert_close(y, torch.zeros_like(y))
+
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_gate_init_one_matches_unconditioned_mlp_after_weight_load(self, device, norm_type):
+        base = NormMLP(10, 20, norm_type=norm_type, dropout=0.0).to(device)
+        conditioned = AdaNormMLP(10, 20, norm_type=norm_type, dropout=0.0, adaln_gate_init=1.0).to(device)
+        conditioned.load_state_dict(base.state_dict(), strict=False)
+
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+
+        assert conditioned.modulation.bias is not None
+        hidden_size = conditioned.fc2.out_features
+        expected_gate = torch.full((hidden_size,), VALID_ADALN_GATE_INITS[1], device=device)
+        assert_close(conditioned.modulation.bias[2 * hidden_size :], expected_gate)
+        assert_close(conditioned(x, conditioning=conditioning), base(x))
 
     @pytest.mark.parametrize("activation", ["relu", "swiglu"])
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+from torch.testing import assert_close
+
+from vit.norm import AdaNorm
+
+
+class TestAdaNorm:
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_zero_init_matches_base_norm(self, device, norm_type):
+        layer = AdaNorm(10, norm_type=norm_type).to(device)
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+
+        y = layer(x, conditioning)
+        expected = layer.norm(x)
+        assert_close(y, expected)
+
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_batch_conditioning_broadcast_matches_expanded_conditioning(self, device, norm_type):
+        layer = AdaNorm(10, norm_type=norm_type).to(device)
+        with torch.no_grad():
+            torch.nn.init.normal_(layer.modulation.weight, std=0.02)
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+        expanded_conditioning = conditioning[:, None, :].expand(-1, x.shape[1], -1)
+
+        y = layer(x, conditioning)
+        y_expanded = layer(x, expanded_conditioning)
+        assert_close(y, y_expanded)
+
+    @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+    def test_backward(self, device, norm_type):
+        layer = AdaNorm(10, norm_type=norm_type).to(device)
+        x = torch.randn(2, 4, 10, device=device)
+        conditioning = torch.randn(2, 10, device=device)
+
+        y = layer(x, conditioning)
+        y.sum().backward()
+        for param in layer.parameters():
+            assert param.grad is not None
+            assert not param.grad.isnan().any()

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from conftest import enable_adaln_gate
 from torch.testing import assert_close
 
 from vit.fused import AdaNormMLP
@@ -91,11 +90,24 @@ class TestTransformerEncoderLayer:
     def test_forward_with_conditioning(self, device):
         layer = TransformerEncoderLayer(64, 128, 4, conditioning_size=32).to(device)
         assert isinstance(layer.mlp, AdaNormMLP)
-        enable_adaln_gate(layer.mlp)
         x = torch.randn(2, 12, 64, device=device)
         conditioning = torch.randn(2, 32, device=device)
         y = layer(x, conditioning=conditioning)
         assert y.shape == x.shape
+
+    def test_conditioned_gate_receives_gradient_at_init(self, device):
+        hidden_size, conditioning_size = 64, 32
+        layer = TransformerEncoderLayer(hidden_size, 128, 4, conditioning_size=conditioning_size).to(device)
+        assert isinstance(layer.mlp, AdaNormMLP)
+        x = torch.randn(2, 12, hidden_size, device=device)
+        conditioning = torch.randn(2, conditioning_size, device=device)
+
+        layer(x, conditioning=conditioning).sum().backward()
+
+        assert layer.mlp.modulation.bias is not None
+        assert layer.mlp.modulation.bias.grad is not None
+        gate_grad = layer.mlp.modulation.bias.grad[2 * hidden_size :]
+        assert torch.count_nonzero(gate_grad).item() > 0
 
     def test_conditioning_requires_conditioning_size(self, device):
         layer = TransformerEncoderLayer(64, 128, 4).to(device)
@@ -328,7 +340,6 @@ class TestTransformerDecoderLayer:
     def test_forward_with_conditioning(self, device):
         layer = TransformerDecoderLayer(64, 128, 4, conditioning_size=32).to(device)
         assert isinstance(layer.mlp, AdaNormMLP)
-        enable_adaln_gate(layer.mlp)
         x = torch.randn(2, 12, 64, device=device)
         kv = torch.randn(2, 8, 64, device=device)
         conditioning = torch.randn(2, 32, device=device)
@@ -518,7 +529,6 @@ class TestCrossAttentionTransformer:
     def test_forward_with_conditioning(self, device):
         layer = CrossAttentionTransformer(64, 128, 4, conditioning_size=32).to(device)
         assert isinstance(layer.mlp, AdaNormMLP)
-        enable_adaln_gate(layer.mlp)
         x = torch.randn(2, 12, 64, device=device)
         kv = torch.randn(2, 8, 64, device=device)
         conditioning = torch.randn(2, 32, device=device)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from torch.testing import assert_close
 
-from vit.fused import AdaNormMLP
+from vit.fused import VALID_ADALN_GATE_INITS, AdaNormMLP
 from vit.transformer import (
     CrossAttentionTransformer,
     TransformerDecoderLayer,
@@ -61,6 +61,11 @@ class TestTransformerEncoderLayer:
     def test_conditioning_size_uses_adanorm_mlp(self):
         layer = TransformerEncoderLayer(64, 128, 4, conditioning_size=32)
         assert isinstance(layer.mlp, AdaNormMLP)
+
+    def test_adaln_gate_init_is_forwarded_to_conditioned_mlp(self):
+        layer = TransformerEncoderLayer(64, 128, 4, conditioning_size=32, adaln_gate_init=VALID_ADALN_GATE_INITS[1])
+        assert isinstance(layer.mlp, AdaNormMLP)
+        assert layer.mlp.adaln_gate_init == VALID_ADALN_GATE_INITS[1]
 
     @pytest.mark.parametrize("layer_scale", [None, 1e-5])
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,7 +1,9 @@
 import pytest
 import torch
+from conftest import enable_adaln_gate
 from torch.testing import assert_close
 
+from vit.fused import AdaNormMLP
 from vit.transformer import (
     CrossAttentionTransformer,
     TransformerDecoderLayer,
@@ -57,6 +59,10 @@ class TestTransformerEncoderLayer:
         assert isinstance(layer.self_attention.q_norm, norm_cls)
         assert isinstance(layer.self_attention.k_norm, norm_cls)
 
+    def test_conditioning_size_uses_adanorm_mlp(self):
+        layer = TransformerEncoderLayer(64, 128, 4, conditioning_size=32)
+        assert isinstance(layer.mlp, AdaNormMLP)
+
     @pytest.mark.parametrize("layer_scale", [None, 1e-5])
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
     def test_forward(self, device, layer_scale, norm_type):
@@ -81,6 +87,54 @@ class TestTransformerEncoderLayer:
             y = transformer_layer(x)
         y.sum().backward()
         _assert_parameter_grads_finite(transformer_layer)
+
+    def test_forward_with_conditioning(self, device):
+        layer = TransformerEncoderLayer(64, 128, 4, conditioning_size=32).to(device)
+        assert isinstance(layer.mlp, AdaNormMLP)
+        enable_adaln_gate(layer.mlp)
+        x = torch.randn(2, 12, 64, device=device)
+        conditioning = torch.randn(2, 32, device=device)
+        y = layer(x, conditioning=conditioning)
+        assert y.shape == x.shape
+
+    def test_conditioning_requires_conditioning_size(self, device):
+        layer = TransformerEncoderLayer(64, 128, 4).to(device)
+        x = torch.randn(2, 12, 64, device=device)
+        conditioning = torch.randn(2, 64, device=device)
+        with pytest.raises(ValueError, match="conditioning is not supported"):
+            layer(x, conditioning=conditioning)
+
+    def test_conditioning_is_subset_with_stochastic_depth(self, device, monkeypatch):
+        batch_size, seq_len, hidden_size, conditioning_size = 8, 16, 64, 32
+        drop_path_rate = 0.25
+        expected_keep_count = _expected_keep_count(batch_size, drop_path_rate)
+        layer = TransformerEncoderLayer(
+            hidden_size=hidden_size,
+            ffn_hidden_size=hidden_size * 2,
+            num_attention_heads=4,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            drop_path_rate=drop_path_rate,
+            conditioning_size=conditioning_size,
+        ).to(device)
+        layer.train()
+        assert isinstance(layer.mlp, AdaNormMLP)
+
+        conditioning_batches: list[int] = []
+        original_mlp_forward = layer.mlp.forward
+
+        def record_mlp_batch(x: torch.Tensor, *, conditioning: torch.Tensor | None = None, **kwargs) -> torch.Tensor:
+            assert conditioning is not None
+            conditioning_batches.append(conditioning.shape[0])
+            return original_mlp_forward(x, conditioning=conditioning, **kwargs)
+
+        monkeypatch.setattr(layer.mlp, "forward", record_mlp_batch)
+
+        x = torch.randn(batch_size, seq_len, hidden_size, device=device)
+        conditioning = torch.randn(batch_size, conditioning_size, device=device)
+        y = layer(x, conditioning=conditioning)
+        assert y.shape == (batch_size, seq_len, hidden_size)
+        assert conditioning_batches == [expected_keep_count]
 
     def test_forward_determinstic(self, device):
         B, L, D = 16, 128, 128
@@ -240,6 +294,10 @@ class TestTransformerDecoderLayer:
         assert isinstance(layer.cross_attention.q_norm, norm_cls)
         assert isinstance(layer.cross_attention.k_norm, norm_cls)
 
+    def test_conditioning_size_uses_adanorm_mlp(self):
+        layer = TransformerDecoderLayer(64, 128, 4, conditioning_size=32)
+        assert isinstance(layer.mlp, AdaNormMLP)
+
     @pytest.mark.parametrize("layer_scale", [None, 1e-5])
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
     def test_forward(self, device, layer_scale, norm_type):
@@ -266,6 +324,16 @@ class TestTransformerDecoderLayer:
             y = transformer_layer(x, kv)
         y.sum().backward()
         _assert_parameter_grads_finite(transformer_layer)
+
+    def test_forward_with_conditioning(self, device):
+        layer = TransformerDecoderLayer(64, 128, 4, conditioning_size=32).to(device)
+        assert isinstance(layer.mlp, AdaNormMLP)
+        enable_adaln_gate(layer.mlp)
+        x = torch.randn(2, 12, 64, device=device)
+        kv = torch.randn(2, 8, 64, device=device)
+        conditioning = torch.randn(2, 32, device=device)
+        y = layer(x, kv, conditioning=conditioning)
+        assert y.shape == x.shape
 
     def test_forward_determinstic(self, device):
         B, L, D = 16, 128, 128
@@ -419,6 +487,10 @@ class TestCrossAttentionTransformer:
         assert isinstance(layer.cross_attention.q_norm, norm_cls)
         assert isinstance(layer.cross_attention.k_norm, norm_cls)
 
+    def test_conditioning_size_uses_adanorm_mlp(self):
+        layer = CrossAttentionTransformer(64, 128, 4, conditioning_size=32)
+        assert isinstance(layer.mlp, AdaNormMLP)
+
     @pytest.mark.parametrize("layer_scale", [None, 1e-5])
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
     def test_forward(self, device, layer_scale, norm_type):
@@ -442,6 +514,16 @@ class TestCrossAttentionTransformer:
             y = transformer_layer(x, kv)
         y.sum().backward()
         _assert_parameter_grads_finite(transformer_layer)
+
+    def test_forward_with_conditioning(self, device):
+        layer = CrossAttentionTransformer(64, 128, 4, conditioning_size=32).to(device)
+        assert isinstance(layer.mlp, AdaNormMLP)
+        enable_adaln_gate(layer.mlp)
+        x = torch.randn(2, 12, 64, device=device)
+        kv = torch.randn(2, 8, 64, device=device)
+        conditioning = torch.randn(2, 32, device=device)
+        y = layer(x, kv, conditioning=conditioning)
+        assert y.shape == x.shape
 
     def test_forward_determinstic(self, device):
         B, L, D = 16, 128, 128

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -11,7 +11,7 @@ import torch.nn as nn
 from torch.testing import assert_close
 from torchao.quantization import Int8WeightOnlyConfig
 
-from vit.fused import AdaNormMLP
+from vit.fused import VALID_ADALN_GATE_INITS, AdaNormMLP
 from vit.head import AttentivePoolHeadConfig, HeadConfig
 from vit.vit import ViT, ViTConfig, ViTFeatures
 
@@ -206,6 +206,25 @@ class TestViT:
         )
         model = ViT(config).to(device)
         assert isinstance(model.get_block(0).mlp, AdaNormMLP)
+
+    def test_adaln_gate_init_is_forwarded_to_blocks(self, device):
+        config = ViTConfig(
+            in_channels=3,
+            patch_size=(16, 16),
+            img_size=(224, 224),
+            depth=1,
+            hidden_size=64,
+            ffn_hidden_size=128,
+            num_attention_heads=4,
+            pos_enc="learnable",
+            conditioning_size=32,
+            adaln_gate_init=VALID_ADALN_GATE_INITS[1],
+            dtype=torch.float32,
+        )
+        model = ViT(config).to(device)
+        block = model.get_block(0)
+        assert isinstance(block.mlp, AdaNormMLP)
+        assert block.mlp.adaln_gate_init == VALID_ADALN_GATE_INITS[1]
 
     def test_rmsnorm_output_norm_preserves_default_eps_behavior(self):
         config = ViTConfig(
@@ -636,6 +655,20 @@ class TestViT:
                 num_attention_heads=4,
                 pos_enc="learnable",
                 norm_type="invalid",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_adaln_gate_init_raises(self):
+        with pytest.raises(ValueError, match="adaln_gate_init must be one of"):
+            ViTConfig(
+                in_channels=3,
+                patch_size=(16, 16),
+                img_size=(224, 224),
+                depth=1,
+                hidden_size=64,
+                ffn_hidden_size=128,
+                num_attention_heads=4,
+                pos_enc="learnable",
+                adaln_gate_init=0.5,
             )
 
     def test_fourier_pos_enc_with_odd_hidden_size_raises(self):

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -8,9 +8,11 @@ from unittest.mock import patch
 import pytest
 import torch
 import torch.nn as nn
+from conftest import enable_model_adaln_gates
 from torch.testing import assert_close
 from torchao.quantization import Int8WeightOnlyConfig
 
+from vit.fused import AdaNormMLP
 from vit.head import HeadConfig
 from vit.vit import ViT, ViTConfig, ViTFeatures
 
@@ -156,6 +158,22 @@ class TestViT:
         L = math.prod(model.stem.tokenized_size(config.img_size))
         assert out.visual_tokens.shape == (2, L, config.hidden_size)
 
+    def test_conditioning_size_uses_adanorm_mlp_blocks(self, device):
+        config = ViTConfig(
+            in_channels=3,
+            patch_size=(16, 16),
+            img_size=(224, 224),
+            depth=1,
+            hidden_size=64,
+            ffn_hidden_size=128,
+            num_attention_heads=4,
+            pos_enc="learnable",
+            conditioning_size=32,
+            dtype=torch.float32,
+        )
+        model = ViT(config).to(device)
+        assert isinstance(model.get_block(0).mlp, AdaNormMLP)
+
     def test_rmsnorm_output_norm_preserves_default_eps_behavior(self):
         config = ViTConfig(
             in_channels=3,
@@ -269,6 +287,30 @@ class TestViT:
         L = math.prod(model.stem.tokenized_size(config.img_size))
         assert out.visual_tokens.shape == (2, L, 128)
 
+    def test_forward_with_conditioning(self, device, config):
+        config = replace(config, conditioning_size=32)
+        x = torch.randn(2, 3, *config.img_size, device=device)
+        conditioning = torch.randn(2, 32, device=device)
+        model = ViT(config).to(device)
+        enable_model_adaln_gates(model)
+        out = model(x, conditioning=conditioning)
+        L = math.prod(model.stem.tokenized_size(config.img_size))
+        assert out.visual_tokens.shape == (2, L, config.hidden_size)
+
+    def test_forward_rejects_conditioning_without_config(self, device, config):
+        x = torch.randn(2, 3, *config.img_size, device=device)
+        conditioning = torch.randn(2, config.hidden_size, device=device)
+        model = ViT(config).to(device)
+        with pytest.raises(ValueError, match="conditioning is not supported"):
+            model(x, conditioning=conditioning)
+
+    def test_forward_requires_conditioning_when_configured(self, device, config):
+        config = replace(config, conditioning_size=32)
+        x = torch.randn(2, 3, *config.img_size, device=device)
+        model = ViT(config).to(device)
+        with pytest.raises(ValueError, match="conditioning is required"):
+            model(x)
+
     @pytest.mark.parametrize("masked", [False, True])
     def test_forward_with_rope(self, device, config, masked):
         x = torch.randn(3, 3, *config.img_size, device=device)
@@ -318,6 +360,19 @@ class TestViT:
         model = ViT(config).to(device)
         with torch.autocast(device_type=device.type, dtype=torch.float32, enabled=True):
             out = model(x)
+        out.dense_features.sum().backward()
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                assert param.grad is not None, f"{name} has no gradient"
+                assert not param.grad.isnan().any(), f"{name} has nan gradient"
+
+    def test_backward_with_conditioning(self, device, config):
+        config = replace(config, conditioning_size=32)
+        x = torch.randn(2, 3, *config.img_size, device=device, requires_grad=True)
+        conditioning = torch.randn(2, 32, device=device)
+        model = ViT(config).to(device)
+        enable_model_adaln_gates(model)
+        out = model(x, conditioning=conditioning)
         out.dense_features.sum().backward()
         for name, param in model.named_parameters():
             if param.requires_grad:
@@ -439,6 +494,15 @@ class TestViT:
             assert (weight >= 0).all(), f"{name} has negative weights"
             assert (weight <= 1).all(), f"{name} has weights greater than 1"
             assert weight.shape == (B, H, L + num_register_tokens, *size)
+
+    def test_forward_attention_weights_with_conditioning(self, device, config):
+        config = replace(config, conditioning_size=32)
+        x = torch.randn(2, 3, *config.img_size, device=device)
+        conditioning = torch.randn(2, 32, device=device)
+        model = ViT(config).to(device)
+        enable_model_adaln_gates(model)
+        weights = model.forward_attention_weights(x, conditioning=conditioning)
+        assert len(weights) == config.depth
 
     def test_quantization(self, device, config):
         torch.random.manual_seed(0)

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import pytest
 import torch
 import torch.nn as nn
-from conftest import enable_model_adaln_gates
 from torch.testing import assert_close
 from torchao.quantization import Int8WeightOnlyConfig
 
@@ -375,7 +374,6 @@ class TestViT:
         x = torch.randn(2, 3, *config.img_size, device=device)
         conditioning = torch.randn(2, 32, device=device)
         model = ViT(config).to(device)
-        enable_model_adaln_gates(model)
         out = model(x, conditioning=conditioning)
         L = math.prod(model.stem.tokenized_size(config.img_size))
         assert out.visual_tokens.shape == (2, L, config.hidden_size)
@@ -454,7 +452,6 @@ class TestViT:
         x = torch.randn(2, 3, *config.img_size, device=device, requires_grad=True)
         conditioning = torch.randn(2, 32, device=device)
         model = ViT(config).to(device)
-        enable_model_adaln_gates(model)
         out = model(x, conditioning=conditioning)
         out.dense_features.sum().backward()
         for name, param in model.named_parameters():
@@ -594,7 +591,6 @@ class TestViT:
         x = torch.randn(2, 3, *config.img_size, device=device)
         conditioning = torch.randn(2, 32, device=device)
         model = ViT(config).to(device)
-        enable_model_adaln_gates(model)
         weights = model.forward_attention_weights(x, conditioning=conditioning)
         assert len(weights) == config.depth
 

--- a/vit/fused.py
+++ b/vit/fused.py
@@ -8,8 +8,8 @@ from torch import Tensor
 from torchao.quantization import quantize_
 
 from .helpers import get_activation
-from .initialization import init_linear
-from .norm import NormType, apply_norm, get_norm_bias, is_layer_norm, make_norm
+from .initialization import init_linear, zero_bias_if_present
+from .norm import NormType, apply_norm, get_norm_bias, is_layer_norm, make_norm, reshape_modulation
 
 
 @torch.compile(fullgraph=True)
@@ -107,15 +107,28 @@ def norm_mlp(
     eps: float,
     dropout: float,
     training: bool,
+    norm_scale_delta: Tensor | None = None,
+    norm_shift: Tensor | None = None,
+    output_gate: Tensor | None = None,
     # fmt: on
 ) -> Tensor:
     if norm_weight is not None:
-        x = apply_norm(x, norm_weight, norm_bias, eps, use_layer_norm=use_layer_norm)
+        x = apply_norm(
+            x,
+            norm_weight,
+            norm_bias,
+            eps,
+            use_layer_norm=use_layer_norm,
+            scale_delta=norm_scale_delta,
+            shift=norm_shift,
+        )
     x = F.linear(x, fc1_weight, fc1_bias)
     x = activation(x)
     x = F.dropout(x, p=dropout, training=training)
     x = F.linear(x, fc2_weight, fc2_bias)
     x = F.dropout(x, p=dropout, training=training, inplace=True)
+    if output_gate is not None:
+        x = x * output_gate
     return x
 
 
@@ -144,10 +157,21 @@ def norm_mlp_glu(
     training: bool,
     limit: float | None = None,
     extra_bias: float | None = None,
+    norm_scale_delta: Tensor | None = None,
+    norm_shift: Tensor | None = None,
+    output_gate: Tensor | None = None,
     # fmt: on
 ) -> Tensor:
     if norm_weight is not None:
-        x = apply_norm(x, norm_weight, norm_bias, eps, use_layer_norm=use_layer_norm)
+        x = apply_norm(
+            x,
+            norm_weight,
+            norm_bias,
+            eps,
+            use_layer_norm=use_layer_norm,
+            scale_delta=norm_scale_delta,
+            shift=norm_shift,
+        )
 
     # FC1 - GLU
     x = F.linear(x, fc1_weight, fc1_bias)
@@ -163,6 +187,8 @@ def norm_mlp_glu(
     # FC2
     x = F.linear(x, fc2_weight, fc2_bias)
     x = F.dropout(x, p=dropout, training=training, inplace=True)
+    if output_gate is not None:
+        x = x * output_gate
     return x
 
 
@@ -214,7 +240,14 @@ class NormMLP(nn.Module):
         quantize_(self.fc1, quantization_config)
         quantize_(self.fc2, quantization_config)
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        *,
+        norm_scale_delta: Tensor | None = None,
+        norm_shift: Tensor | None = None,
+        output_gate: Tensor | None = None,
+    ) -> Tensor:
         if self._is_glu:
             return norm_mlp_glu(
                 # fmt: off
@@ -232,6 +265,9 @@ class NormMLP(nn.Module):
                 self.training,
                 self.limit,
                 self.extra_bias,
+                norm_scale_delta,
+                norm_shift,
+                output_gate,
                 # fmt: on
             )
         else:
@@ -249,10 +285,104 @@ class NormMLP(nn.Module):
                 self.norm.eps or 1e-5,
                 self.dropout.p,
                 self.training,
+                norm_scale_delta,
+                norm_shift,
+                output_gate,
                 # fmt: on
             )
 
     if TYPE_CHECKING:
 
-        def __call__(self, x: Tensor) -> Tensor:
-            return self.forward(x)
+        def __call__(
+            self,
+            x: Tensor,
+            *,
+            norm_scale_delta: Tensor | None = None,
+            norm_shift: Tensor | None = None,
+            output_gate: Tensor | None = None,
+        ) -> Tensor:
+            return self.forward(x, norm_scale_delta=norm_scale_delta, norm_shift=norm_shift, output_gate=output_gate)
+
+
+class AdaNormMLP(NormMLP):
+    def __init__(
+        self,
+        hidden_size: int,
+        ffn_hidden_size: int,
+        bias: bool = True,
+        activation: str = "gelu",
+        eps: float = 1e-5,
+        dropout: float = 0.1,
+        limit: float | None = None,
+        extra_bias: float | None = None,
+        quantization_config: Any | None = None,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        norm_type: NormType = "rmsnorm",
+        conditioning_size: int | None = None,
+    ):
+        super().__init__(
+            hidden_size=hidden_size,
+            ffn_hidden_size=ffn_hidden_size,
+            bias=bias,
+            activation=activation,
+            eps=eps,
+            dropout=dropout,
+            limit=limit,
+            extra_bias=extra_bias,
+            quantization_config=quantization_config,
+            device=device,
+            dtype=dtype,
+            norm_type=norm_type,
+        )
+        factory_kwargs = {"device": device, "dtype": dtype}
+        self.conditioning_size = hidden_size if conditioning_size is None else conditioning_size
+        self.conditioning_activation = nn.SiLU()
+        self.modulation = nn.Linear(self.conditioning_size, 3 * hidden_size, **factory_kwargs)
+        self.reset_modulation_parameters()
+
+    @torch.no_grad()
+    def reset_modulation_parameters(self) -> None:
+        nn.init.zeros_(self.modulation.weight)
+        zero_bias_if_present(self.modulation)
+
+    def forward(
+        self,
+        x: Tensor,
+        *,
+        conditioning: Tensor | None = None,
+        norm_scale_delta: Tensor | None = None,
+        norm_shift: Tensor | None = None,
+        output_gate: Tensor | None = None,
+    ) -> Tensor:
+        if conditioning is None:
+            raise ValueError("conditioning is required for AdaNormMLP")
+        if norm_scale_delta is not None or norm_shift is not None or output_gate is not None:
+            raise ValueError("AdaNormMLP does not accept manual modulation tensors when conditioning is provided")
+        modulation = self.modulation(self.conditioning_activation(conditioning))
+        adaptive_shift, adaptive_scale_delta, adaptive_output_gate = modulation.chunk(3, dim=-1)
+        return super().forward(
+            x,
+            norm_scale_delta=reshape_modulation(adaptive_scale_delta, x),
+            norm_shift=reshape_modulation(adaptive_shift, x),
+            output_gate=reshape_modulation(adaptive_output_gate, x),
+        )
+
+    if TYPE_CHECKING:
+
+        def __call__(
+            self,
+            x: Tensor,
+            *,
+            conditioning: Tensor | None = None,
+            norm_scale_delta: Tensor | None = None,
+            norm_shift: Tensor | None = None,
+            output_gate: Tensor | None = None,
+        ) -> Tensor:
+            return self.forward(
+                x,
+                conditioning=conditioning,
+                norm_scale_delta=norm_scale_delta,
+                norm_shift=norm_shift,
+                output_gate=output_gate,
+            )

--- a/vit/fused.py
+++ b/vit/fused.py
@@ -12,6 +12,14 @@ from .initialization import init_linear, zero_bias_if_present
 from .norm import NormType, apply_norm, get_norm_bias, is_layer_norm, make_norm, reshape_modulation
 
 
+VALID_ADALN_GATE_INITS = (0.0, 1.0)
+
+
+def validate_adaln_gate_init(adaln_gate_init: float) -> None:
+    if adaln_gate_init not in VALID_ADALN_GATE_INITS:
+        raise ValueError(f"adaln_gate_init must be one of {VALID_ADALN_GATE_INITS}, got {adaln_gate_init}")
+
+
 @torch.compile(fullgraph=True)
 def norm_linear(
     # fmt: off
@@ -320,6 +328,7 @@ class AdaNormMLP(NormMLP):
         dtype: torch.dtype | None = None,
         norm_type: NormType = "rmsnorm",
         conditioning_size: int | None = None,
+        adaln_gate_init: float = 0.0,
     ):
         super().__init__(
             hidden_size=hidden_size,
@@ -335,8 +344,10 @@ class AdaNormMLP(NormMLP):
             dtype=dtype,
             norm_type=norm_type,
         )
+        validate_adaln_gate_init(adaln_gate_init)
         factory_kwargs = {"device": device, "dtype": dtype}
         self.conditioning_size = hidden_size if conditioning_size is None else conditioning_size
+        self.adaln_gate_init = adaln_gate_init
         self.conditioning_activation = nn.SiLU()
         self.modulation = nn.Linear(self.conditioning_size, 3 * hidden_size, **factory_kwargs)
         self.reset_modulation_parameters()
@@ -345,6 +356,9 @@ class AdaNormMLP(NormMLP):
     def reset_modulation_parameters(self) -> None:
         nn.init.zeros_(self.modulation.weight)
         zero_bias_if_present(self.modulation)
+        if self.modulation.bias is not None:
+            hidden_size = self.fc2.out_features
+            self.modulation.bias[2 * hidden_size :].fill_(self.adaln_gate_init)
 
     def forward(
         self,

--- a/vit/norm.py
+++ b/vit/norm.py
@@ -1,9 +1,11 @@
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
+
+from .initialization import zero_bias_if_present
 
 
 NormType = Literal["rmsnorm", "layernorm"]
@@ -44,7 +46,106 @@ def apply_norm(
     eps: float,
     *,
     use_layer_norm: bool,
+    scale_delta: Tensor | None = None,
+    shift: Tensor | None = None,
 ) -> Tensor:
     if use_layer_norm:
-        return F.layer_norm(x, x.shape[-1:], weight=weight, bias=bias, eps=eps)
-    return F.rms_norm(x, x.shape[-1:], weight=weight, eps=eps)
+        x = F.layer_norm(x, x.shape[-1:], weight=weight, bias=None, eps=eps)
+    else:
+        x = F.rms_norm(x, x.shape[-1:], weight=weight, eps=eps)
+
+    if scale_delta is not None:
+        x = x * (1 + scale_delta)
+    if bias is not None:
+        x = x + bias
+    if shift is not None:
+        x = x + shift
+    return x
+
+
+def reshape_modulation(modulation: Tensor, x: Tensor) -> Tensor:
+    if modulation.ndim > x.ndim:
+        raise ValueError(f"modulation rank {modulation.ndim} exceeds input rank {x.ndim}")
+    if modulation.shape[-1] != x.shape[-1]:
+        raise ValueError(
+            f"modulation hidden size must match input hidden size, got {modulation.shape[-1]} and {x.shape[-1]}"
+        )
+    if modulation.ndim == 1:
+        return modulation
+
+    prefix = modulation.shape[:-1]
+    expected_prefix = x.shape[: len(prefix)]
+    if prefix != expected_prefix:
+        raise ValueError(
+            f"modulation shape {tuple(modulation.shape)} is not compatible with input shape {tuple(x.shape)}"
+        )
+
+    expand_shape = (*prefix, *([1] * (x.ndim - modulation.ndim)), modulation.shape[-1])
+    return modulation.reshape(expand_shape)
+
+
+@torch.compile(fullgraph=True)
+def ada_norm(
+    x: Tensor,
+    conditioning: Tensor,
+    norm_weight: Tensor,
+    norm_bias: Tensor | None,
+    modulation_weight: Tensor,
+    modulation_bias: Tensor | None,
+    use_layer_norm: bool,
+    eps: float,
+) -> Tensor:
+    modulation = F.linear(F.silu(conditioning), modulation_weight, modulation_bias)
+    scale_delta, shift = modulation.chunk(2, dim=-1)
+    return apply_norm(
+        x,
+        norm_weight,
+        norm_bias,
+        eps,
+        use_layer_norm=use_layer_norm,
+        scale_delta=reshape_modulation(scale_delta, x),
+        shift=reshape_modulation(shift, x),
+    )
+
+
+class AdaNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        conditioning_size: int | None = None,
+        *,
+        norm_type: NormType = "rmsnorm",
+        eps: float = 1e-5,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.conditioning_size = hidden_size if conditioning_size is None else conditioning_size
+        self.norm = make_norm(hidden_size, norm_type, eps=eps, **factory_kwargs)
+        self._use_layer_norm = is_layer_norm(norm_type)
+        self.modulation = nn.Linear(self.conditioning_size, 2 * hidden_size, **factory_kwargs)
+        self.reset_parameters()
+
+    @torch.no_grad()
+    def reset_parameters(self) -> None:
+        nn.init.zeros_(self.modulation.weight)
+        zero_bias_if_present(self.modulation)
+
+    def forward(self, x: Tensor, conditioning: Tensor) -> Tensor:
+        return ada_norm(
+            x,
+            conditioning,
+            self.norm.weight,
+            get_norm_bias(self.norm),
+            self.modulation.weight,
+            self.modulation.bias,
+            self._use_layer_norm,
+            self.norm.eps or 1e-5,
+        )
+
+    if TYPE_CHECKING:
+
+        def __call__(self, x: Tensor, conditioning: Tensor) -> Tensor:
+            return self.forward(x, conditioning)

--- a/vit/transformer.py
+++ b/vit/transformer.py
@@ -137,6 +137,13 @@ def _zero_residual_outputs(*modules: nn.Linear) -> None:
         _zero_linear(module)
 
 
+@torch.no_grad()
+def _zero_mlp_residual_output(mlp: NormMLP) -> None:
+    if isinstance(mlp, AdaNormMLP):
+        return
+    _zero_linear(mlp.fc2)
+
+
 class TransformerEncoderLayer(nn.Module):
     def __init__(
         self,
@@ -203,7 +210,8 @@ class TransformerEncoderLayer(nn.Module):
             if layer_scale is not None
             else nn.Identity()
         )
-        _zero_residual_outputs(self.self_attention.out_proj, self.mlp.fc2)
+        _zero_residual_outputs(self.self_attention.out_proj)
+        _zero_mlp_residual_output(self.mlp)
         self.apply_quantization(mlp_quantization_config, qkv_quantization_config, attn_quantization_config)
 
     def apply_quantization(
@@ -320,7 +328,8 @@ class TransformerDecoderLayer(nn.Module):
             if layer_scale is not None
             else nn.Identity()
         )
-        _zero_residual_outputs(self.self_attention.out_proj, self.cross_attention.out_proj, self.mlp.fc2)
+        _zero_residual_outputs(self.self_attention.out_proj, self.cross_attention.out_proj)
+        _zero_mlp_residual_output(self.mlp)
         self.apply_quantization(mlp_quantization_config, qkv_quantization_config, attn_quantization_config)
 
     def apply_quantization(
@@ -444,7 +453,8 @@ class CrossAttentionTransformer(nn.Module):
             if layer_scale is not None
             else nn.Identity()
         )
-        _zero_residual_outputs(self.cross_attention.out_proj, self.mlp.fc2)
+        _zero_residual_outputs(self.cross_attention.out_proj)
+        _zero_mlp_residual_output(self.mlp)
         self.apply_quantization(mlp_quantization_config, qkv_quantization_config, attn_quantization_config)
 
     def apply_quantization(

--- a/vit/transformer.py
+++ b/vit/transformer.py
@@ -90,6 +90,7 @@ def _make_mlp(
     extra_bias: float | None,
     quantization_config: Any | None,
     conditioning_size: int | None,
+    adaln_gate_init: float,
     device: torch.device | None,
     dtype: torch.dtype | None,
 ) -> NormMLP:
@@ -106,6 +107,7 @@ def _make_mlp(
             extra_bias=extra_bias,
             quantization_config=quantization_config,
             conditioning_size=conditioning_size,
+            adaln_gate_init=adaln_gate_init,
             device=device,
             dtype=dtype,
         )
@@ -168,6 +170,7 @@ class TransformerEncoderLayer(nn.Module):
         norm_type: NormType = "rmsnorm",
         qk_normalization: bool = False,
         conditioning_size: int | None = None,
+        adaln_gate_init: float = 0.0,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -197,6 +200,7 @@ class TransformerEncoderLayer(nn.Module):
             extra_bias=glu_extra_bias,
             quantization_config=None,
             conditioning_size=conditioning_size,
+            adaln_gate_init=adaln_gate_init,
             device=device,
             dtype=dtype,
         )
@@ -268,6 +272,7 @@ class TransformerDecoderLayer(nn.Module):
         norm_type: NormType = "rmsnorm",
         qk_normalization: bool = False,
         conditioning_size: int | None = None,
+        adaln_gate_init: float = 0.0,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -310,6 +315,7 @@ class TransformerDecoderLayer(nn.Module):
             extra_bias=glu_extra_bias,
             quantization_config=None,
             conditioning_size=conditioning_size,
+            adaln_gate_init=adaln_gate_init,
             device=device,
             dtype=dtype,
         )
@@ -411,6 +417,7 @@ class CrossAttentionTransformer(nn.Module):
         norm_type: NormType = "rmsnorm",
         qk_normalization: bool = False,
         conditioning_size: int | None = None,
+        adaln_gate_init: float = 0.0,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -440,6 +447,7 @@ class CrossAttentionTransformer(nn.Module):
             extra_bias=glu_extra_bias,
             quantization_config=None,
             conditioning_size=conditioning_size,
+            adaln_gate_init=adaln_gate_init,
             device=device,
             dtype=dtype,
         )

--- a/vit/transformer.py
+++ b/vit/transformer.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 from torch import Tensor
 
 from .attention import CrossAttention, SelfAttention
-from .fused import NormMLP
+from .fused import AdaNormMLP, NormMLP
 from .initialization import zero_bias_if_present
 from .layer_scale import LayerScale
 from .norm import NormType
@@ -54,6 +54,77 @@ def _subset_batch(tensor: Tensor, keep_indices: Tensor | None, full_batch_size: 
     return tensor.index_select(0, keep_indices)
 
 
+def _subset_conditioning(tensor: Tensor, keep_indices: Tensor | None, full_batch_size: int) -> Tensor:
+    if tensor.ndim == 1:
+        return tensor
+    return _subset_batch(tensor, keep_indices, full_batch_size)
+
+
+def _forward_mlp(
+    mlp: NormMLP,
+    x: Tensor,
+    conditioning: Tensor | None,
+    keep_indices: Tensor | None,
+    full_batch_size: int,
+) -> Tensor:
+    if isinstance(mlp, AdaNormMLP):
+        if conditioning is None:
+            raise ValueError("conditioning is required when transformer conditioning_size is set")
+        conditioning = _subset_conditioning(conditioning, keep_indices, full_batch_size)
+        return mlp(x, conditioning=conditioning)
+    if conditioning is not None:
+        raise ValueError("conditioning is not supported unless transformer conditioning_size is set")
+    return mlp(x)
+
+
+def _make_mlp(
+    hidden_size: int,
+    ffn_hidden_size: int,
+    *,
+    bias: bool,
+    activation: str,
+    norm_type: NormType,
+    eps: float,
+    dropout: float,
+    limit: float | None,
+    extra_bias: float | None,
+    quantization_config: Any | None,
+    conditioning_size: int | None,
+    device: torch.device | None,
+    dtype: torch.dtype | None,
+) -> NormMLP:
+    if conditioning_size is not None:
+        return AdaNormMLP(
+            hidden_size=hidden_size,
+            ffn_hidden_size=ffn_hidden_size,
+            bias=bias,
+            activation=activation,
+            norm_type=norm_type,
+            eps=eps,
+            dropout=dropout,
+            limit=limit,
+            extra_bias=extra_bias,
+            quantization_config=quantization_config,
+            conditioning_size=conditioning_size,
+            device=device,
+            dtype=dtype,
+        )
+    return NormMLP(
+        hidden_size=hidden_size,
+        ffn_hidden_size=ffn_hidden_size,
+        bias=bias,
+        activation=activation,
+        norm_type=norm_type,
+        eps=eps,
+        dropout=dropout,
+        limit=limit,
+        extra_bias=extra_bias,
+        quantization_config=quantization_config,
+        device=device,
+        dtype=dtype,
+    )
+
+
 @torch.no_grad()
 def _zero_linear(module: nn.Linear) -> None:
     nn.init.zeros_(module.weight)
@@ -89,6 +160,7 @@ class TransformerEncoderLayer(nn.Module):
         dtype: torch.dtype | None = None,
         norm_type: NormType = "rmsnorm",
         qk_normalization: bool = False,
+        conditioning_size: int | None = None,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -106,7 +178,7 @@ class TransformerEncoderLayer(nn.Module):
             qk_normalization=qk_normalization,
             **factory_kwargs,
         )
-        self.mlp = NormMLP(
+        self.mlp = _make_mlp(
             hidden_size=hidden_size,
             ffn_hidden_size=ffn_hidden_size,
             bias=mlp_bias,
@@ -117,7 +189,9 @@ class TransformerEncoderLayer(nn.Module):
             limit=glu_limit,
             extra_bias=glu_extra_bias,
             quantization_config=None,
-            **factory_kwargs,
+            conditioning_size=conditioning_size,
+            device=device,
+            dtype=dtype,
         )
         self.layer_scale_attn = (
             LayerScale(hidden_size, layer_scale, inplace=True, **factory_kwargs)
@@ -143,7 +217,7 @@ class TransformerEncoderLayer(nn.Module):
         if qkv_quantization_config is not None or attn_quantization_config is not None:
             self.self_attention.apply_quantization(qkv_quantization_config, attn_quantization_config)
 
-    def forward(self, x: Tensor, rope: Tensor | None = None) -> Tensor:
+    def forward(self, x: Tensor, rope: Tensor | None = None, conditioning: Tensor | None = None) -> Tensor:
         batch_size = x.shape[0]
 
         x_residual, keep_indices, residual_scale = _select_residual_subset(x, self.drop_path_rate, self.training)
@@ -152,14 +226,14 @@ class TransformerEncoderLayer(nn.Module):
         x = _merge_residual_subset(x, o, keep_indices, residual_scale)
 
         x_residual, keep_indices, residual_scale = _select_residual_subset(x, self.drop_path_rate, self.training)
-        o = self.layer_scale_mlp(self.mlp(x_residual))
+        o = self.layer_scale_mlp(_forward_mlp(self.mlp, x_residual, conditioning, keep_indices, batch_size))
         x = _merge_residual_subset(x, o, keep_indices, residual_scale)
         return x
 
     if TYPE_CHECKING:
 
-        def __call__(self, x: Tensor, rope: Tensor | None = None) -> Tensor:
-            return self.forward(x, rope)
+        def __call__(self, x: Tensor, rope: Tensor | None = None, conditioning: Tensor | None = None) -> Tensor:
+            return self.forward(x, rope, conditioning)
 
 
 class TransformerDecoderLayer(nn.Module):
@@ -185,6 +259,7 @@ class TransformerDecoderLayer(nn.Module):
         dtype: torch.dtype | None = None,
         norm_type: NormType = "rmsnorm",
         qk_normalization: bool = False,
+        conditioning_size: int | None = None,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -215,7 +290,7 @@ class TransformerDecoderLayer(nn.Module):
             qk_normalization=qk_normalization,
             **factory_kwargs,
         )
-        self.mlp = NormMLP(
+        self.mlp = _make_mlp(
             hidden_size=hidden_size,
             ffn_hidden_size=ffn_hidden_size,
             bias=mlp_bias,
@@ -226,7 +301,9 @@ class TransformerDecoderLayer(nn.Module):
             limit=glu_limit,
             extra_bias=glu_extra_bias,
             quantization_config=None,
-            **factory_kwargs,
+            conditioning_size=conditioning_size,
+            device=device,
+            dtype=dtype,
         )
         self.layer_scale_attn = (
             LayerScale(hidden_size, layer_scale, inplace=True, **factory_kwargs)
@@ -259,7 +336,14 @@ class TransformerDecoderLayer(nn.Module):
         if qkv_quantization_config is not None or attn_quantization_config is not None:
             self.cross_attention.apply_quantization(qkv_quantization_config, attn_quantization_config)
 
-    def forward(self, x: Tensor, kv: Tensor, rope_q: Tensor | None = None, rope_k: Tensor | None = None) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        kv: Tensor,
+        rope_q: Tensor | None = None,
+        rope_k: Tensor | None = None,
+        conditioning: Tensor | None = None,
+    ) -> Tensor:
         batch_size = x.shape[0]
 
         x_residual, keep_indices, residual_scale = _select_residual_subset(x, self.drop_path_rate, self.training)
@@ -277,14 +361,21 @@ class TransformerDecoderLayer(nn.Module):
         x = _merge_residual_subset(x, o, keep_indices, residual_scale)
 
         x_residual, keep_indices, residual_scale = _select_residual_subset(x, self.drop_path_rate, self.training)
-        o = self.layer_scale_mlp(self.mlp(x_residual))
+        o = self.layer_scale_mlp(_forward_mlp(self.mlp, x_residual, conditioning, keep_indices, batch_size))
         x = _merge_residual_subset(x, o, keep_indices, residual_scale)
         return x
 
     if TYPE_CHECKING:
 
-        def __call__(self, x: Tensor, kv: Tensor, rope_q: Tensor | None = None, rope_k: Tensor | None = None) -> Tensor:
-            return self.forward(x, kv, rope_q, rope_k)
+        def __call__(
+            self,
+            x: Tensor,
+            kv: Tensor,
+            rope_q: Tensor | None = None,
+            rope_k: Tensor | None = None,
+            conditioning: Tensor | None = None,
+        ) -> Tensor:
+            return self.forward(x, kv, rope_q, rope_k, conditioning)
 
 
 class CrossAttentionTransformer(nn.Module):
@@ -310,6 +401,7 @@ class CrossAttentionTransformer(nn.Module):
         dtype: torch.dtype | None = None,
         norm_type: NormType = "rmsnorm",
         qk_normalization: bool = False,
+        conditioning_size: int | None = None,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -327,7 +419,7 @@ class CrossAttentionTransformer(nn.Module):
             qk_normalization=qk_normalization,
             **factory_kwargs,
         )
-        self.mlp = NormMLP(
+        self.mlp = _make_mlp(
             hidden_size=hidden_size,
             ffn_hidden_size=ffn_hidden_size,
             bias=mlp_bias,
@@ -338,7 +430,9 @@ class CrossAttentionTransformer(nn.Module):
             limit=glu_limit,
             extra_bias=glu_extra_bias,
             quantization_config=None,
-            **factory_kwargs,
+            conditioning_size=conditioning_size,
+            device=device,
+            dtype=dtype,
         )
         self.layer_scale_cross = (
             LayerScale(hidden_size, layer_scale, inplace=True, **factory_kwargs)
@@ -364,7 +458,14 @@ class CrossAttentionTransformer(nn.Module):
         if qkv_quantization_config is not None or attn_quantization_config is not None:
             self.cross_attention.apply_quantization(qkv_quantization_config, attn_quantization_config)
 
-    def forward(self, x: Tensor, kv: Tensor, rope_q: Tensor | None = None, rope_k: Tensor | None = None) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        kv: Tensor,
+        rope_q: Tensor | None = None,
+        rope_k: Tensor | None = None,
+        conditioning: Tensor | None = None,
+    ) -> Tensor:
         batch_size = x.shape[0]
 
         x_residual, keep_indices, residual_scale = _select_residual_subset(x, self.drop_path_rate, self.training)
@@ -377,11 +478,18 @@ class CrossAttentionTransformer(nn.Module):
         x = _merge_residual_subset(x, o, keep_indices, residual_scale)
 
         x_residual, keep_indices, residual_scale = _select_residual_subset(x, self.drop_path_rate, self.training)
-        o = self.layer_scale_mlp(self.mlp(x_residual))
+        o = self.layer_scale_mlp(_forward_mlp(self.mlp, x_residual, conditioning, keep_indices, batch_size))
         x = _merge_residual_subset(x, o, keep_indices, residual_scale)
         return x
 
     if TYPE_CHECKING:
 
-        def __call__(self, x: Tensor, kv: Tensor, rope_q: Tensor | None = None, rope_k: Tensor | None = None) -> Tensor:
-            return self.forward(x, kv, rope_q, rope_k)
+        def __call__(
+            self,
+            x: Tensor,
+            kv: Tensor,
+            rope_q: Tensor | None = None,
+            rope_k: Tensor | None = None,
+            conditioning: Tensor | None = None,
+        ) -> Tensor:
+            return self.forward(x, kv, rope_q, rope_k, conditioning)

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -9,6 +9,7 @@ import yaml
 from torch import Tensor
 from torch.utils.checkpoint import checkpoint
 
+from .fused import validate_adaln_gate_init
 from .head import (
     AttentivePoolHead,
     AttentivePoolHeadConfig,
@@ -66,6 +67,14 @@ def register_constructors():
 
 @dataclass(frozen=True)
 class ViTConfig:
+    """Configuration for ViT construction.
+
+    When enabling conditioned MLPs via `conditioning_size`, keep `adaln_gate_init=0.0`
+    for the default AdaLN-Zero initialization. Set `adaln_gate_init=1.0` when
+    converting a pretrained unconditioned MLP stack into a conditioned one so the
+    loaded MLP path is preserved at initialization.
+    """
+
     # Inputs
     in_channels: int
     patch_size: Sequence[int]
@@ -103,6 +112,7 @@ class ViTConfig:
     # Memory optimization
     activation_checkpointing: bool = False
     conditioning_size: int | None = None
+    adaln_gate_init: float = 0.0
 
     # Master weight dtype (default BF16)
     dtype: torch.dtype = torch.bfloat16
@@ -126,6 +136,7 @@ class ViTConfig:
             raise ValueError(f"hidden_size ({self.hidden_size}) must be even when using Fourier positional encoding")
         if self.conditioning_size is not None and self.conditioning_size <= 0:
             raise ValueError(f"conditioning_size must be positive when provided, got {self.conditioning_size}")
+        validate_adaln_gate_init(self.adaln_gate_init)
 
     def instantiate(self, device: torch.device | None = None) -> "ViT":
         return ViT(self, device=device)
@@ -372,6 +383,7 @@ class ViT(nn.Module):
             device=device,
             dtype=resolved_dtype,
             conditioning_size=self.config.conditioning_size,
+            adaln_gate_init=self.config.adaln_gate_init,
         )
 
     def create_decoder_layer(
@@ -404,6 +416,7 @@ class ViT(nn.Module):
             device=device,
             dtype=resolved_dtype,
             conditioning_size=self.config.conditioning_size,
+            adaln_gate_init=self.config.adaln_gate_init,
         )
 
     def create_cross_attention_layer(
@@ -436,6 +449,7 @@ class ViT(nn.Module):
             device=device,
             dtype=resolved_dtype,
             conditioning_size=self.config.conditioning_size,
+            adaln_gate_init=self.config.adaln_gate_init,
         )
 
     def create_head(

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -89,6 +89,7 @@ class ViTConfig:
 
     # Memory optimization
     activation_checkpointing: bool = False
+    conditioning_size: int | None = None
 
     # Master weight dtype (default BF16)
     dtype: torch.dtype = torch.bfloat16
@@ -110,6 +111,8 @@ class ViTConfig:
             raise ValueError(f"Unsupported norm_type: {self.norm_type}")
         if self.pos_enc == "fourier" and self.hidden_size % 2 != 0:
             raise ValueError(f"hidden_size ({self.hidden_size}) must be even when using Fourier positional encoding")
+        if self.conditioning_size is not None and self.conditioning_size <= 0:
+            raise ValueError(f"conditioning_size must be positive when provided, got {self.conditioning_size}")
 
     def instantiate(self, device: torch.device | None = None) -> "ViT":
         return ViT(self, device=device)
@@ -350,6 +353,7 @@ class ViT(nn.Module):
             attn_quantization_config=attn_quantization_config,
             device=device,
             dtype=self.config.dtype,
+            conditioning_size=self.config.conditioning_size,
         )
 
     def create_decoder_layer(
@@ -379,6 +383,7 @@ class ViT(nn.Module):
             attn_quantization_config=attn_quantization_config,
             device=device,
             dtype=self.config.dtype,
+            conditioning_size=self.config.conditioning_size,
         )
 
     def create_cross_attention_layer(
@@ -408,6 +413,7 @@ class ViT(nn.Module):
             attn_quantization_config=attn_quantization_config,
             device=device,
             dtype=self.config.dtype,
+            conditioning_size=self.config.conditioning_size,
         )
 
     def get_head(self, name: str) -> Head | TransposedConv2dHead | UpsampleHead:
@@ -496,13 +502,23 @@ class ViT(nn.Module):
     def normalize_patch_embeddings(self, x: Tensor) -> Tensor:
         return self.patch_embed_norm(x) if self.patch_embed_norm is not None else x
 
+    def _validate_conditioning(self, conditioning: Tensor | None) -> None:
+        if self.config.conditioning_size is None:
+            if conditioning is not None:
+                raise ValueError("conditioning is not supported unless config.conditioning_size is set")
+        elif conditioning is None:
+            raise ValueError("conditioning is required when config.conditioning_size is set")
+
     def forward(
         self,
         x: Tensor,
         mask: Tensor | None = None,
         rope_seed: int | None = None,
         output_norm: bool = True,
+        conditioning: Tensor | None = None,
     ) -> ViTFeatures:
+        self._validate_conditioning(conditioning)
+
         # Prepare transformer input
         tokenized_size = self.stem.tokenized_size(x.shape[2:])
         x = self.stem(x)
@@ -517,9 +533,9 @@ class ViT(nn.Module):
         for block in self.blocks:
             assert isinstance(block, TransformerEncoderLayer)
             if self.config.activation_checkpointing and self.training:
-                x = cast(Tensor, checkpoint(block, x, rope, use_reentrant=False))
+                x = cast(Tensor, checkpoint(block, x, rope, conditioning, use_reentrant=False))
             else:
-                x = block(x, rope=rope)
+                x = block(x, rope=rope, conditioning=conditioning)
 
         # Prepare output
         x = self.output_norm(x) if output_norm else x
@@ -533,8 +549,9 @@ class ViT(nn.Module):
             mask: Tensor | None = None,
             rope_seed: int | None = None,
             output_norm: bool = True,
+            conditioning: Tensor | None = None,
         ) -> ViTFeatures:
-            return self.forward(x, mask, rope_seed, output_norm)
+            return self.forward(x, mask, rope_seed, output_norm, conditioning)
 
     @torch.no_grad()
     def _reshape_attention_weights(self, w: Tensor, tokenized_size: Sequence[int]) -> Tensor:
@@ -543,7 +560,9 @@ class ViT(nn.Module):
         w = w[..., self.config.num_register_tokens :].view(B, H, Lq, *tokenized_size)
         return w.contiguous()
 
-    def forward_attention_weights(self, x: Tensor) -> dict[str, Tensor]:
+    def forward_attention_weights(self, x: Tensor, conditioning: Tensor | None = None) -> dict[str, Tensor]:
+        self._validate_conditioning(conditioning)
+
         # Prepare transformer input
         tokenized_size = self.stem.tokenized_size(x.shape[2:])
         x = self.stem(x)
@@ -556,7 +575,7 @@ class ViT(nn.Module):
             assert isinstance(block, TransformerEncoderLayer)
             w_i = block.self_attention.forward_weights(x)
             weights[f"layer_{i}"] = self._reshape_attention_weights(w_i, tokenized_size)
-            x = block(x)
+            x = block(x, conditioning=conditioning)
 
         return weights
 


### PR DESCRIPTION
## Summary
- add standalone adaptive normalization primitives with a compiled `ada_norm(...)` functional and `AdaNorm` module
- extend the fused `NormMLP` path with optional norm modulation and output gating, then add `AdaNormMLP` for AdaLN-Zero style conditioned MLPs
- propagate opt-in conditioning through transformer layers and `ViT` so a single conditioning vector can modulate every block MLP
- add configurable `adaln_gate_init` so conditioned models can either keep AdaLN-Zero defaults (`0.0`) or preserve pretrained unconditioned MLP behavior (`1.0`) during conversion

## Changes
- add adaptive norm modulation support to `vit/norm.py` and `vit/fused.py`
- add `conditioning_size` support to transformer encoder, decoder, and cross-attention layers in `vit/transformer.py`
- add `conditioning_size`, `adaln_gate_init`, and `conditioning=` plumbing to `ViTConfig` and `ViT` in `vit/vit.py`
- validate conditioned vs unconditioned usage explicitly so configured models require `conditioning` and unconfigured models reject it
- handle selective stochastic depth and activation checkpointing with conditioned MLP calls
- avoid double-zeroing conditioned transformer MLP residual outputs so AdaNormMLP paths train correctly at initialization
- add regression coverage for standalone AdaNorm, AdaNormMLP, conditioned transformer layers, conditioned ViT forwards, conditioned attention-weight extraction, checkpointing, and pretrained-compatible gate init

## Test Plan
- [x] `make check`
- [x] `uv run pytest tests/test_norm.py tests/test_fused.py`
- [x] `uv run pytest tests/test_transformer.py tests/test_vit.py tests/test_checkpointing.py`

## Notes
- conditioning is opt-in via `conditioning_size`; existing unconditioned model paths keep their prior behavior
- `adaln_gate_init=0.0` keeps the default AdaLN-Zero initialization for scratch training
- `adaln_gate_init=1.0` is intended for converting pretrained unconditioned MLP stacks into conditioned ones while preserving the loaded MLP path at initialization