### PR TITLE
Add dtype overrides for ViT factory methods

### DIFF
--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -15,6 +15,15 @@ from vit.head import AttentivePoolHeadConfig, HeadConfig
 from vit.vit import ViT, ViTConfig, ViTFeatures
 
 
+FACTORY_METHOD_NAMES = ("create_encoder_layer", "create_decoder_layer", "create_cross_attention_layer")
+HEAD_FACTORY_CASES = (
+    ("cls", HeadConfig(out_features=10)),
+    ("pool", AttentivePoolHeadConfig(out_features=10)),
+)
+FACTORY_OVERRIDE_DTYPE = torch.float32
+FACTORY_CONFIG_DTYPE = torch.bfloat16
+
+
 @pytest.fixture(params=[pytest.param(False, id="2d"), pytest.param(True, id="3d")])
 def config(request):
     is_3d = request.param
@@ -40,6 +49,31 @@ def assert_all_requires_grad(module: Any):
 def assert_none_requires_grad(module: Any):
     assert isinstance(module, nn.Module)
     assert not any(p.requires_grad for p in module.parameters())
+
+
+def assert_module_params_dtype_and_device(module: nn.Module, dtype: torch.dtype, device: torch.device) -> None:
+    for name, param in module.named_parameters():
+        assert param.dtype == dtype, f"Parameter {name} has dtype {param.dtype}, expected {dtype}"
+        assert param.device == device, f"Parameter {name} on device {param.device}, expected {device}"
+
+
+def make_factory_override_config(**config_overrides: Any) -> ViTConfig:
+    return ViTConfig(
+        in_channels=3,
+        patch_size=(16, 16),
+        img_size=(224, 224),
+        depth=1,
+        hidden_size=64,
+        ffn_hidden_size=128,
+        num_attention_heads=4,
+        pos_enc="learnable",
+        dtype=FACTORY_CONFIG_DTYPE,
+        **config_overrides,
+    )
+
+
+def make_factory_override_model(device: torch.device, **config_overrides: Any) -> ViT:
+    return ViT(make_factory_override_config(**config_overrides), device=device)
 
 
 class TestViT:
@@ -219,6 +253,49 @@ class TestViT:
                 assert param.device == device, (
                     f"Head {head_name} param {name} on device {param.device}, expected {device}"
                 )
+
+    @pytest.mark.parametrize("factory_name", FACTORY_METHOD_NAMES)
+    def test_layer_factories_accept_dtype_override_without_module_to(self, device, factory_name):
+        model = make_factory_override_model(device)
+        factory = getattr(model, factory_name)
+
+        with patch.object(nn.Module, "to", side_effect=AssertionError("factory method should not cast via Module.to")):
+            module = factory(device=device, dtype=FACTORY_OVERRIDE_DTYPE)
+
+        assert_module_params_dtype_and_device(module, FACTORY_OVERRIDE_DTYPE, device)
+
+    @pytest.mark.parametrize("factory_name", FACTORY_METHOD_NAMES)
+    def test_layer_factories_default_to_config_dtype(self, device, factory_name):
+        model = make_factory_override_model(device)
+        factory = getattr(model, factory_name)
+        module = factory(device=device)
+        assert_module_params_dtype_and_device(module, FACTORY_CONFIG_DTYPE, device)
+
+    @pytest.mark.parametrize(("name", "head_config"), HEAD_FACTORY_CASES)
+    def test_create_head_accepts_dtype_override_without_module_to(self, device, name, head_config):
+        model = make_factory_override_model(device)
+
+        with patch.object(nn.Module, "to", side_effect=AssertionError("head factory should not cast via Module.to")):
+            head = model.create_head(name, head_config, device=device, dtype=FACTORY_OVERRIDE_DTYPE)
+
+        assert_module_params_dtype_and_device(head, FACTORY_OVERRIDE_DTYPE, device)
+
+    @pytest.mark.parametrize(("name", "head_config"), HEAD_FACTORY_CASES)
+    def test_create_head_defaults_to_config_dtype(self, device, name, head_config):
+        model = make_factory_override_model(device)
+        head = model.create_head(name, head_config, device=device)
+        assert_module_params_dtype_and_device(head, FACTORY_CONFIG_DTYPE, device)
+
+    def test_vit_init_uses_create_head_factory(self, device):
+        class HeadDtypeOverrideViT(ViT):
+            def create_head(self, name, head_config, device=None, dtype=None):
+                return super().create_head(name, head_config, device=device, dtype=FACTORY_OVERRIDE_DTYPE)
+
+        config = make_factory_override_config(heads={"cls": HeadConfig(out_features=10)})
+        model = HeadDtypeOverrideViT(config, device=device)
+
+        assert model.stem.patch.weight.dtype == FACTORY_CONFIG_DTYPE
+        assert_module_params_dtype_and_device(model.heads["cls"], FACTORY_OVERRIDE_DTYPE, device)
 
     def test_prefix_tokens_use_bounded_truncated_normal_init(self):
         config = ViTConfig(

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -28,6 +28,10 @@ from .tokens import apply_mask, create_mask
 from .transformer import CrossAttentionTransformer, TransformerDecoderLayer, TransformerEncoderLayer
 
 
+HeadConfigType = HeadConfig | AttentivePoolHeadConfig | TransposedConv2dHeadConfig | UpsampleHeadConfig
+HeadModuleType = Head | AttentivePoolHead | TransposedConv2dHead | UpsampleHead
+
+
 def _parse_dtype(dtype_str: str | None) -> torch.dtype | None:
     """Convert string dtype representation to torch.dtype."""
     if dtype_str is None:
@@ -106,9 +110,7 @@ class ViTConfig:
     patch_embed_normalization: bool = False
 
     # Heads
-    heads: dict[str, HeadConfig | AttentivePoolHeadConfig | TransposedConv2dHeadConfig | UpsampleHeadConfig] = field(
-        default_factory=dict
-    )
+    heads: dict[str, HeadConfigType] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Validate configuration parameters."""
@@ -317,7 +319,7 @@ class ViT(nn.Module):
         self.self_attention_requires_grad_(self.config.self_attention_requires_grad)
 
         self.heads = nn.ModuleDict(
-            {name: head_config.instantiate(config, **factory_kwargs) for name, head_config in config.heads.items()}
+            {name: self.create_head(name, head_config, device=device) for name, head_config in config.heads.items()}
         )
 
     def apply_quantization(
@@ -334,13 +336,18 @@ class ViT(nn.Module):
     def config(self) -> ViTConfig:
         return self._config
 
+    def _resolve_factory_dtype(self, dtype: torch.dtype | None) -> torch.dtype:
+        return self.config.dtype if dtype is None else dtype
+
     def create_encoder_layer(
         self,
         mlp_quantization_config: Any | None = None,
         qkv_quantization_config: Any | None = None,
         attn_quantization_config: Any | None = None,
         device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
     ) -> TransformerEncoderLayer:
+        resolved_dtype = self._resolve_factory_dtype(dtype)
         return TransformerEncoderLayer(
             hidden_size=self.config.hidden_size,
             ffn_hidden_size=self.config.ffn_hidden_size,
@@ -360,7 +367,7 @@ class ViT(nn.Module):
             qkv_quantization_config=qkv_quantization_config,
             attn_quantization_config=attn_quantization_config,
             device=device,
-            dtype=self.config.dtype,
+            dtype=resolved_dtype,
         )
 
     def create_decoder_layer(
@@ -369,7 +376,9 @@ class ViT(nn.Module):
         qkv_quantization_config: Any | None = None,
         attn_quantization_config: Any | None = None,
         device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
     ) -> TransformerDecoderLayer:
+        resolved_dtype = self._resolve_factory_dtype(dtype)
         return TransformerDecoderLayer(
             hidden_size=self.config.hidden_size,
             ffn_hidden_size=self.config.ffn_hidden_size,
@@ -389,7 +398,7 @@ class ViT(nn.Module):
             qkv_quantization_config=qkv_quantization_config,
             attn_quantization_config=attn_quantization_config,
             device=device,
-            dtype=self.config.dtype,
+            dtype=resolved_dtype,
         )
 
     def create_cross_attention_layer(
@@ -398,7 +407,9 @@ class ViT(nn.Module):
         qkv_quantization_config: Any | None = None,
         attn_quantization_config: Any | None = None,
         device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
     ) -> CrossAttentionTransformer:
+        resolved_dtype = self._resolve_factory_dtype(dtype)
         return CrossAttentionTransformer(
             hidden_size=self.config.hidden_size,
             ffn_hidden_size=self.config.ffn_hidden_size,
@@ -418,12 +429,25 @@ class ViT(nn.Module):
             qkv_quantization_config=qkv_quantization_config,
             attn_quantization_config=attn_quantization_config,
             device=device,
-            dtype=self.config.dtype,
+            dtype=resolved_dtype,
         )
 
-    def get_head(self, name: str) -> Head | AttentivePoolHead | TransposedConv2dHead | UpsampleHead:
+    def create_head(
+        self,
+        name: str,
+        head_config: HeadConfigType,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> HeadModuleType:
+        _ = name
+        resolved_dtype = self._resolve_factory_dtype(dtype)
+        head = head_config.instantiate(self.config, device=device, dtype=resolved_dtype)
+        assert isinstance(head, HeadModuleType)
+        return head
+
+    def get_head(self, name: str) -> HeadModuleType:
         head = self.heads[name]
-        assert isinstance(head, Head | AttentivePoolHead | TransposedConv2dHead | UpsampleHead)
+        assert isinstance(head, HeadModuleType)
         return head
 
     def get_block(self, i: int) -> TransformerEncoderLayer:


### PR DESCRIPTION
## Motivation
`ViTConfig.dtype` controls the default master weight dtype, but `ViT`'s layer factory helpers hardcoded that dtype and head construction bypassed a common factory hook. That made it awkward to create auxiliary layers or heads in a different weight dtype and prevented subclasses from customizing head construction during `ViT.__init__`.

## Solution
Add optional `dtype` overrides to the `ViT` factory helpers and route head construction through a new `create_head(...)` hook. The override is forwarded directly into module constructors so weights are instantiated in the requested dtype instead of being initialized and then cast.

## Changes
- add `HeadConfigType` and `HeadModuleType` aliases to simplify `ViT` head typing
- extend `create_encoder_layer`, `create_decoder_layer`, and `create_cross_attention_layer` with an optional `dtype` override that defaults to `config.dtype`
- add `ViT.create_head(...)` and use it during model initialization so subclasses can override head construction
- add regression tests for explicit dtype overrides, default fallback behavior, direct-instantiation without `Module.to(...)`, and subclass-driven head overrides during `ViT.__init__`

## Test plan
- [x] `uv run pytest tests/test_vit.py -k "dtype_override or create_head or create_head_factory or layer_factories"`
- [x] `make check`

## Test suite changes (Required)
- [x] Added regression tests for factory-level dtype overrides and direct-instantiation behavior
- [x] No unit tests were removed
- [x] No existing unit tests were materially altered

Generated with Codex
