### PR TITLE
Ship runnable benchmark entry points

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
             - run:
                 name: Run static type checking
                 command: make types
+            - run:
+                name: Validate distribution artifacts
+                command: make check-distribution
             - codecov/upload:
                 files: coverage.xml
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: clean clean-env check quality style tag-version test env upload upload-test
+.PHONY: check-distribution clean clean-env check quality style tag-version test env upload upload-test
 
 PROJECT=vit
-QUALITY_DIRS=$(PROJECT) tests benchmark
-CLEAN_DIRS=$(PROJECT) tests benchmark
+QUALITY_DIRS=$(PROJECT) tests benchmark tools
+CLEAN_DIRS=$(PROJECT) tests benchmark tools
 UV_VERSION=0.11.28
 UVX=uvx
 UV=$(UVX) --from uv==$(UV_VERSION) uv
@@ -17,7 +17,14 @@ check: ## run quality checks and unit tests
 	$(MAKE) style
 	$(MAKE) quality
 	$(MAKE) types
+	$(MAKE) check-distribution
 	$(MAKE) test
+
+check-distribution: ## build a wheel and validate its console-script targets
+	@dist_dir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$dist_dir"' EXIT; \
+	$(UV) build --wheel --out-dir "$$dist_dir"; \
+	$(PYTHON) tools/validate_wheel.py "$$dist_dir"/*.whl
 
 clean: ## remove cache files
 	find $(CLEAN_DIRS) -path '*/__pycache__/*' -delete

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Transformer residual output projections are zero-initialized by default (`attn o
 This library can be installed with the following command
 
 ```bash
-pip install vit @ git+https://github.com/TidalPaladin/vit.git
+pip install "vit @ git+https://github.com/TidalPaladin/vit.git"
 ```
 
 For benchmarking capabilities, install with the benchmarking extras:

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,54 +1,107 @@
 #!/usr/bin/env python
 """Benchmarking tools for ViT models."""
 
-from .benchmark import (
-    BenchmarkResult,
-    PassMode,
-    benchmark_latency,
-    benchmark_memory,
-    compute_gflops,
-    create_input_from_config,
-    run_full_benchmark,
-    warmup_model,
-)
-from .component_benchmark import (
-    ComparisonResult,
-    ComparisonSummary,
-    ComponentBenchmarkCase,
-    ComponentBenchmarkResult,
-    ComponentBenchmarkStats,
-    compare_benchmark_runs,
-    configure_runtime,
-    load_benchmark_run,
-    run_component_benchmark_case,
-    run_component_benchmark_suite,
-    save_benchmark_run,
-)
-from .plotting import PlotFormat, plot_benchmark_results, plot_multi_metric_comparison, plot_throughput_analysis
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
+
+if TYPE_CHECKING:
+    from .benchmark import (
+        BenchmarkResult as BenchmarkResult,
+        PassMode as PassMode,
+        benchmark_latency as benchmark_latency,
+        benchmark_memory as benchmark_memory,
+        compute_gflops as compute_gflops,
+        create_input_from_config as create_input_from_config,
+        run_full_benchmark as run_full_benchmark,
+        warmup_model as warmup_model,
+    )
+    from .component_benchmark import (
+        ComparisonResult as ComparisonResult,
+        ComparisonSummary as ComparisonSummary,
+        ComponentBenchmarkCase as ComponentBenchmarkCase,
+        ComponentBenchmarkResult as ComponentBenchmarkResult,
+        ComponentBenchmarkStats as ComponentBenchmarkStats,
+        compare_benchmark_runs as compare_benchmark_runs,
+        configure_runtime as configure_runtime,
+        load_benchmark_run as load_benchmark_run,
+        run_component_benchmark_case as run_component_benchmark_case,
+        run_component_benchmark_suite as run_component_benchmark_suite,
+        save_benchmark_run as save_benchmark_run,
+    )
+    from .plotting import (
+        PlotFormat as PlotFormat,
+        plot_benchmark_results as plot_benchmark_results,
+        plot_multi_metric_comparison as plot_multi_metric_comparison,
+        plot_throughput_analysis as plot_throughput_analysis,
+    )
+
+
+_LAZY_EXPORTS = {
+    "BenchmarkResult": ("benchmark", "BenchmarkResult"),
+    "PassMode": ("benchmark", "PassMode"),
+    "benchmark_latency": ("benchmark", "benchmark_latency"),
+    "benchmark_memory": ("benchmark", "benchmark_memory"),
+    "compute_gflops": ("benchmark", "compute_gflops"),
+    "create_input_from_config": ("benchmark", "create_input_from_config"),
+    "run_full_benchmark": ("benchmark", "run_full_benchmark"),
+    "warmup_model": ("benchmark", "warmup_model"),
+    "ComparisonResult": ("component_benchmark", "ComparisonResult"),
+    "ComparisonSummary": ("component_benchmark", "ComparisonSummary"),
+    "ComponentBenchmarkCase": ("component_benchmark", "ComponentBenchmarkCase"),
+    "ComponentBenchmarkResult": ("component_benchmark", "ComponentBenchmarkResult"),
+    "ComponentBenchmarkStats": ("component_benchmark", "ComponentBenchmarkStats"),
+    "compare_benchmark_runs": ("component_benchmark", "compare_benchmark_runs"),
+    "configure_runtime": ("component_benchmark", "configure_runtime"),
+    "load_benchmark_run": ("component_benchmark", "load_benchmark_run"),
+    "run_component_benchmark_case": ("component_benchmark", "run_component_benchmark_case"),
+    "run_component_benchmark_suite": ("component_benchmark", "run_component_benchmark_suite"),
+    "save_benchmark_run": ("component_benchmark", "save_benchmark_run"),
+    "PlotFormat": ("plotting", "PlotFormat"),
+    "plot_benchmark_results": ("plotting", "plot_benchmark_results"),
+    "plot_multi_metric_comparison": ("plotting", "plot_multi_metric_comparison"),
+    "plot_throughput_analysis": ("plotting", "plot_throughput_analysis"),
+}
 
 __all__ = [
     "BenchmarkResult",
-    "ComponentBenchmarkCase",
-    "ComponentBenchmarkStats",
-    "ComponentBenchmarkResult",
     "ComparisonResult",
     "ComparisonSummary",
+    "ComponentBenchmarkCase",
+    "ComponentBenchmarkResult",
+    "ComponentBenchmarkStats",
     "PassMode",
     "PlotFormat",
     "benchmark_latency",
     "benchmark_memory",
-    "compute_gflops",
-    "create_input_from_config",
-    "run_full_benchmark",
-    "run_component_benchmark_case",
-    "run_component_benchmark_suite",
-    "save_benchmark_run",
-    "load_benchmark_run",
     "compare_benchmark_runs",
+    "compute_gflops",
     "configure_runtime",
-    "warmup_model",
+    "create_input_from_config",
+    "load_benchmark_run",
     "plot_benchmark_results",
     "plot_multi_metric_comparison",
     "plot_throughput_analysis",
+    "run_component_benchmark_case",
+    "run_component_benchmark_suite",
+    "run_full_benchmark",
+    "save_benchmark_run",
+    "warmup_model",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Load public benchmark symbols only when requested."""
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError as error:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from error
+
+    attribute = getattr(import_module(f".{module_name}", __name__), attribute_name)
+    globals()[name] = attribute
+    return attribute
+
+
+def __dir__() -> list[str]:
+    """Include lazily loaded public symbols in interactive discovery."""
+    return sorted({*globals(), *__all__})

--- a/benchmark/cli.py
+++ b/benchmark/cli.py
@@ -6,12 +6,11 @@ import csv
 from pathlib import Path
 
 import torch
-from tqdm import tqdm
 
 from vit import ViTConfig
 
-from .benchmark import run_full_benchmark
-from .plotting import plot_benchmark_results, plot_multi_metric_comparison, plot_throughput_analysis
+
+OPTIONAL_DEPENDENCY_MODULES = {"matplotlib", "tqdm"}
 
 
 def parse_resolution(resolution_str: str) -> tuple[int, ...]:
@@ -162,6 +161,17 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    try:
+        from tqdm import tqdm
+
+        from .benchmark import run_full_benchmark
+        from .plotting import plot_benchmark_results, plot_multi_metric_comparison, plot_throughput_analysis
+    except ModuleNotFoundError as error:
+        missing_module = error.name.partition(".")[0] if error.name else None
+        if missing_module in OPTIONAL_DEPENDENCY_MODULES:
+            parser.error("benchmark dependencies are not installed; install 'vit[benchmarking]'")
+        raise
 
     # Parse resolutions
     resolutions = [parse_resolution(r) for r in args.resolutions]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ filterwarnings = []
 vit-benchmark = "benchmark.cli:main"
 vit-component-benchmark = "benchmark.component_cli:main"
 
+[project.optional-dependencies]
+benchmarking = [
+    "matplotlib==3.11.0",
+    "tqdm==4.68.4",
+]
+
 [dependency-groups]
 benchmarking = [
     "matplotlib==3.11.0",
@@ -90,3 +96,6 @@ dev = [
     "pdbpp==0.12.1",
     {include-group = "benchmarking"},
 ]
+
+[tool.hatch.build.targets.wheel]
+packages = ["vit", "benchmark"]

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,6 +1,8 @@
 """Tests for installed-distribution metadata and contents."""
 
 import shlex
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 from zipfile import ZipFile
@@ -14,6 +16,31 @@ PROJECT_ROOT = Path(__file__).parents[1]
 BENCHMARK_DEPENDENCIES = {"matplotlib==3.11.0", "tqdm==4.68.4"}
 BENCHMARK_PACKAGES = {"vit", "benchmark"}
 ENTRY_POINTS_PATH = "vit-0.1.1.dist-info/entry_points.txt"
+OPTIONAL_DEPENDENCY_BLOCKER = """
+import importlib
+import importlib.abc
+import importlib.util
+import sys
+
+
+class OptionalDependencyBlocker(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, fullname, path, target=None):
+        if fullname.partition(".")[0] in {"matplotlib", "tqdm"}:
+            return importlib.util.spec_from_loader(fullname, self)
+        return None
+
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        raise ModuleNotFoundError(f"No module named {module.__name__!r}", name=module.__name__)
+
+
+sys.meta_path.insert(0, OptionalDependencyBlocker())
+entrypoint = importlib.import_module(sys.argv[1])
+sys.argv = [sys.argv[1], "--help"]
+entrypoint.main()
+"""
 
 
 def test_benchmark_distribution_configuration() -> None:
@@ -39,6 +66,20 @@ def test_readme_git_install_commands_are_single_requirements() -> None:
         assert len(arguments) == 3
         assert arguments[:2] == ["pip", "install"]
         assert " @ git+https://github.com/TidalPaladin/vit.git" in arguments[2]
+
+
+@pytest.mark.parametrize("entrypoint", ["benchmark.cli", "benchmark.component_cli"])
+def test_benchmark_entrypoint_help_without_optional_dependencies(entrypoint: str) -> None:
+    """Always-installed benchmark commands must provide help without the benchmarking extra."""
+    result = subprocess.run(
+        [sys.executable, "-c", OPTIONAL_DEPENDENCY_BLOCKER, entrypoint],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_wheel_validation_rejects_missing_console_script_module(tmp_path: Path) -> None:

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,0 +1,62 @@
+"""Tests for installed-distribution metadata and contents."""
+
+import shlex
+import tomllib
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+from tools.validate_wheel import validate_console_script_targets
+
+
+PROJECT_ROOT = Path(__file__).parents[1]
+BENCHMARK_DEPENDENCIES = {"matplotlib==3.11.0", "tqdm==4.68.4"}
+BENCHMARK_PACKAGES = {"vit", "benchmark"}
+ENTRY_POINTS_PATH = "vit-0.1.1.dist-info/entry_points.txt"
+
+
+def test_benchmark_distribution_configuration() -> None:
+    """The wheel must ship benchmark modules and expose their dependencies as an extra."""
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    optional_dependencies = set(pyproject["project"]["optional-dependencies"]["benchmarking"])
+    wheel_packages = set(pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"])
+
+    assert optional_dependencies == BENCHMARK_DEPENDENCIES
+    assert BENCHMARK_PACKAGES <= wheel_packages
+
+
+def test_readme_git_install_commands_are_single_requirements() -> None:
+    """Each direct-reference requirement must be one shell argument to pip."""
+    readme = (PROJECT_ROOT / "README.md").read_text()
+    install_commands = [line for line in readme.splitlines() if line.startswith("pip install")]
+
+    assert install_commands
+    for command in install_commands:
+        arguments = shlex.split(command)
+        assert len(arguments) == 3
+        assert arguments[:2] == ["pip", "install"]
+        assert " @ git+https://github.com/TidalPaladin/vit.git" in arguments[2]
+
+
+def test_wheel_validation_rejects_missing_console_script_module(tmp_path: Path) -> None:
+    """Artifact validation must detect a console script whose module was not shipped."""
+    wheel_path = tmp_path / "vit-0.1.1-py3-none-any.whl"
+    with ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr(ENTRY_POINTS_PATH, "[console_scripts]\nvit-benchmark = benchmark.cli:main\n")
+
+    with pytest.raises(ValueError, match="benchmark.cli"):
+        validate_console_script_targets(wheel_path)
+
+
+def test_wheel_validation_accepts_packaged_console_script_module(tmp_path: Path) -> None:
+    """A package module satisfies the console-script artifact contract."""
+    wheel_path = tmp_path / "vit-0.1.1-py3-none-any.whl"
+    with ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr(ENTRY_POINTS_PATH, "[console_scripts]\nvit-benchmark = benchmark.cli:main\n")
+        wheel.writestr("benchmark/__init__.py", "")
+        wheel.writestr("benchmark/cli.py", "def main(): ...\n")
+
+    validate_console_script_targets(wheel_path)

--- a/tools/validate_wheel.py
+++ b/tools/validate_wheel.py
@@ -1,0 +1,51 @@
+"""Validate that wheel console-script targets are present in the artifact."""
+
+from __future__ import annotations
+
+import argparse
+from configparser import ConfigParser
+from pathlib import Path
+from zipfile import ZipFile
+
+
+ENTRY_POINTS_SUFFIX = ".dist-info/entry_points.txt"
+
+
+def validate_console_script_targets(wheel_path: Path) -> None:
+    """Raise when a wheel omits a module targeted by a console script."""
+    with ZipFile(wheel_path) as wheel:
+        wheel_files = set(wheel.namelist())
+        entry_point_files = [path for path in wheel_files if path.endswith(ENTRY_POINTS_SUFFIX)]
+        if len(entry_point_files) != 1:
+            raise ValueError(f"Expected one entry_points.txt in {wheel_path}, found {len(entry_point_files)}")
+
+        parser = ConfigParser(interpolation=None)
+        parser.read_string(wheel.read(entry_point_files[0]).decode())
+
+        missing_modules = []
+        for target in parser["console_scripts"].values():
+            module_name = target.partition(":")[0].strip()
+            module_path = module_name.replace(".", "/")
+            module_candidates = {f"{module_path}.py", f"{module_path}/__init__.py"}
+            if module_candidates.isdisjoint(wheel_files):
+                missing_modules.append(module_name)
+
+    if missing_modules:
+        formatted_modules = ", ".join(sorted(missing_modules))
+        raise ValueError(f"Console-script target modules are missing from {wheel_path}: {formatted_modules}")
+
+
+def main() -> int:
+    """Validate one or more wheel paths supplied on the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheels", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    for wheel_path in args.wheels:
+        validate_console_script_targets(wheel_path)
+        print(f"Validated console-script targets in {wheel_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1425,6 +1425,12 @@ dependencies = [
     { name = "torchao" },
 ]
 
+[package.optional-dependencies]
+benchmarking = [
+    { name = "matplotlib" },
+    { name = "tqdm" },
+]
+
 [package.dev-dependencies]
 benchmarking = [
     { name = "matplotlib" },
@@ -1445,12 +1451,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "matplotlib", marker = "extra == 'benchmarking'", specifier = "==3.11.0" },
     { name = "numpy", marker = "python_full_version < '3.12'", specifier = "==2.4.6" },
     { name = "numpy", marker = "python_full_version >= '3.12'", specifier = "==2.5.1" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "torch", specifier = "==2.13.0" },
     { name = "torchao", specifier = "==0.17.0" },
+    { name = "tqdm", marker = "extra == 'benchmarking'", specifier = "==4.68.4" },
 ]
+provides-extras = ["benchmarking"]
 
 [package.metadata.requires-dev]
 benchmarking = [


### PR DESCRIPTION
## Motivation

Published wheels declare `vit-benchmark` and `vit-component-benchmark`, but the artifacts omit the `benchmark` package that provides both targets. The documented `benchmarking` extra is also absent from package metadata, so installed commands fail before argument parsing and pip cannot install the advertised benchmark dependencies.

Addresses #101.

## Solution

Package both top-level Python modules explicitly, publish the existing benchmark dependency set as a project extra, and validate every wheel console-script target against the files inside the artifact. The distribution check now runs in the standard local gate and CircleCI.

## Changes

- Include `vit/` and `benchmark/` in Hatch wheel builds.
- Add the `benchmarking` optional dependency metadata and refresh `uv.lock`.
- Add a wheel validator that rejects console-script targets whose modules are missing.
- Lazy-load optional benchmark exports and parse CLI help before importing benchmark-only dependencies.
- Run the artifact check through `make check-distribution`, `make check`, and CircleCI.
- Quote the README's direct-reference install requirement so pip receives one argument.

## Test plan

- [x] `make quality`
- [x] `make types`
- [x] `make test-ci` (408 passed, 258 skipped, 6 deselected; 94% production coverage)
- [x] `make check-distribution`
- [x] Install the built wheel with `vit[benchmarking]` in a clean temporary environment.
- [x] Run installed `vit-benchmark --help` and `vit-component-benchmark --help` outside the source checkout.

## Test suite changes

Added six distribution tests covering wheel package and extra configuration, shell-safe README requirements, both failure and success paths for console-script target validation, and help output when optional benchmark dependencies are unavailable. No existing tests were removed or materially altered.

## Risks

The contributor dependency group and installed extra intentionally carry the same pinned benchmark dependencies. Future dependency updates must keep those two declarations aligned. The new CI step also adds one wheel build to the test job.

Generated with Codex.