### PR TITLE
Fix full-model benchmark execution contracts

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -195,7 +195,10 @@ Run complete benchmark suite on a ViT configuration.
 - `config`: ViTConfig to benchmark
 - `batch_size`: Batch size for benchmarking
 - `device`: Device to run benchmark on
-- `pass_mode`: "forward", "backward", or "forward_backward"
+- `pass_mode`: workload measured by the benchmark:
+  - `"forward"`: inference-mode model forward pass
+  - `"backward"`: autograd backward pass after untimed graph construction
+  - `"forward_backward"`: model forward pass, loss construction, and autograd backward pass
 - `num_warmup_iters`: Number of warmup iterations
 - `num_latency_iters`: Number of iterations for latency measurement
 - `num_memory_iters`: Number of iterations for memory measurement

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -247,6 +247,12 @@ def benchmark_memory(
     max_memory_mb = 0.0
 
     for _ in range(num_iters):
+        backward_loss: Tensor | None = None
+        if pass_mode == "backward":
+            model.train()
+            model.zero_grad()
+            backward_loss = _benchmark_loss(model(input_tensor))
+
         # Reset memory stats
         torch.cuda.reset_peak_memory_stats(device)
         torch.cuda.empty_cache()
@@ -255,6 +261,10 @@ def benchmark_memory(
             model.eval()
             with torch.inference_mode():
                 _ = model(input_tensor)
+        elif pass_mode == "backward":
+            assert backward_loss is not None
+            backward_loss.backward()
+            model.zero_grad()
         else:
             model.train()
             _benchmark_loss(model(input_tensor)).backward()

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -2,6 +2,7 @@
 """Core benchmarking functions for ViT models."""
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -10,7 +11,7 @@ import torch.nn as nn
 from torch import Tensor
 from tqdm import tqdm
 
-from vit import ViT, ViTConfig
+from vit import ViT, ViTConfig, ViTFeatures
 
 
 PassMode = Literal["forward", "backward", "forward_backward"]
@@ -70,18 +71,8 @@ def warmup_model(
     else:
         model.train()
         for _ in range(num_warmup_iters):
-            output = model(input_tensor)
-
-            # Compute a simple loss for backward pass
-            if isinstance(output, torch.Tensor):
-                loss = output.mean()
-            else:
-                # For ViTFeatures, use the dense features
-                loss = output.dense_features.mean()
-
-            if pass_mode in ["backward", "forward_backward"]:
-                loss.backward()
-                model.zero_grad()
+            _benchmark_loss(model(input_tensor)).backward()
+            model.zero_grad()
 
 
 def compute_gflops(model: ViT, input_shape: tuple[int, ...]) -> float:
@@ -172,7 +163,7 @@ def benchmark_latency(
     if device is None:
         device = next(model.parameters()).device
 
-    latencies = []
+    latencies: list[float] = []
 
     if pass_mode == "forward":
         model.eval()
@@ -192,31 +183,40 @@ def benchmark_latency(
     else:
         model.train()
         for _ in range(num_iters):
-            if device.type == "cuda":
-                torch.cuda.synchronize(device)
-
-            start_time = time.perf_counter()
-
-            output = model(input_tensor)
-
-            # Compute loss
-            if isinstance(output, torch.Tensor):
-                loss = output.mean()
+            model.zero_grad()
+            if pass_mode == "backward":
+                output = model(input_tensor)
+                loss = _benchmark_loss(output)
+                latency_ms = _time_work(device, loss.backward)
             else:
-                loss = output.dense_features.mean()
-
-            if pass_mode in ["backward", "forward_backward"]:
-                loss.backward()
-
-            if device.type == "cuda":
-                torch.cuda.synchronize(device)
-
-            end_time = time.perf_counter()
-            latencies.append((end_time - start_time) * 1000)  # Convert to ms
-
+                latency_ms = _time_work(device, lambda: _forward_and_backward(model, input_tensor))
+            latencies.append(latency_ms)
             model.zero_grad()
 
     return sum(latencies) / len(latencies)
+
+
+def _benchmark_loss(output: Tensor | ViTFeatures) -> Tensor:
+    """Create the scalar loss used by training-pass benchmarks."""
+    if isinstance(output, torch.Tensor):
+        return output.mean()
+    return output.dense_features.mean()
+
+
+def _forward_and_backward(model: nn.Module, input_tensor: Tensor) -> None:
+    """Run the complete training workload measured by forward_backward."""
+    _benchmark_loss(model(input_tensor)).backward()
+
+
+def _time_work(device: torch.device, work: Callable[[], None]) -> float:
+    """Synchronize a device and time one benchmark workload."""
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    start_time = time.perf_counter()
+    work()
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    return (time.perf_counter() - start_time) * 1000
 
 
 def benchmark_memory(
@@ -257,17 +257,7 @@ def benchmark_memory(
                 _ = model(input_tensor)
         else:
             model.train()
-            output = model(input_tensor)
-
-            # Compute loss
-            if isinstance(output, torch.Tensor):
-                loss = output.mean()
-            else:
-                loss = output.dense_features.mean()
-
-            if pass_mode in ["backward", "forward_backward"]:
-                loss.backward()
-
+            _benchmark_loss(model(input_tensor)).backward()
             model.zero_grad()
 
         # Get peak memory

--- a/benchmark/cli.py
+++ b/benchmark/cli.py
@@ -3,6 +3,8 @@
 
 import argparse
 import csv
+import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 import torch
@@ -23,7 +25,10 @@ def parse_resolution(resolution_str: str) -> tuple[int, ...]:
     Returns:
         Tuple of resolution dimensions.
     """
-    return tuple(int(x.strip()) for x in resolution_str.split(","))
+    resolution = tuple(int(x.strip()) for x in resolution_str.split(","))
+    if len(resolution) == 1:
+        return resolution * 2
+    return resolution
 
 
 def save_results_to_csv(results: list, output_path: Path) -> None:
@@ -69,7 +74,7 @@ def save_results_to_csv(results: list, output_path: Path) -> None:
             )
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> int:
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
         description="Benchmark ViT models with various configurations and resolutions.",
@@ -87,7 +92,7 @@ def main() -> None:
         "--resolutions",
         nargs="+",
         required=True,
-        help="Resolution(s) to benchmark (e.g., '224' or '224,224' for 2D, '64,224,224' for 3D)",
+        help="Resolution(s) to benchmark (e.g., '224' for square 2D, '224,224' for 2D, '64,224,224' for 3D)",
     )
 
     parser.add_argument(
@@ -109,7 +114,7 @@ def main() -> None:
         type=str,
         choices=["forward", "backward", "forward_backward"],
         default="forward",
-        help="Type of pass to benchmark",
+        help="Workload to time: inference forward, autograd backward only, or combined forward and backward",
     )
 
     parser.add_argument(
@@ -161,44 +166,55 @@ def main() -> None:
         help="Skip generating plots",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Parse resolutions
     resolutions = [parse_resolution(r) for r in args.resolutions]
+
+    try:
+        device = torch.device(args.device)
+    except RuntimeError as error:
+        print(f"vit-benchmark failed: invalid device {args.device!r}: {error}", file=sys.stderr)
+        return 2
 
     # Load configs
     configs = []
     for config_path in args.configs:
         config_path = Path(config_path)
-        config = ViTConfig.from_yaml(config_path)
+        try:
+            config = ViTConfig.from_yaml(config_path)
+        except Exception as error:
+            print(f"vit-benchmark failed: could not load {config_path}: {error}", file=sys.stderr)
+            return 2
         config_name = config_path.stem
         configs.append((config_name, config))
 
     print(f"Loaded {len(configs)} configuration(s)")
     print(f"Testing {len(resolutions)} resolution(s)")
-    print(f"Device: {args.device}")
+    print(f"Device: {device}")
     print(f"Pass mode: {args.pass_mode}")
     print(f"Batch size: {args.batch_size}")
     print()
 
     # Run benchmarks
     all_results = []
+    runtime_errors = 0
 
     total_benchmarks = len(configs) * len(resolutions)
     with tqdm(total=total_benchmarks, desc="Overall progress") as overall_pbar:
         for config_name, config in configs:
             for resolution in resolutions:
-                # Create modified config with new resolution
-                config_dict = config.__dict__.copy()
-                config_dict["img_size"] = resolution
-                modified_config = ViTConfig(**config_dict)
-
-                # Run benchmark
                 try:
+                    # Create modified config with new resolution
+                    config_dict = config.__dict__.copy()
+                    config_dict["img_size"] = resolution
+                    modified_config = ViTConfig(**config_dict)
+
+                    # Run benchmark
                     result = run_full_benchmark(
                         config=modified_config,
                         batch_size=args.batch_size,
-                        device=args.device,
+                        device=device,
                         pass_mode=args.pass_mode,
                         num_warmup_iters=args.warmup_iters,
                         num_latency_iters=args.latency_iters,
@@ -215,17 +231,22 @@ def main() -> None:
                         f"{result.memory_mb:.0f}MB, "
                         f"{result.gflops:.1f} GFLOPs"
                     )
-                except Exception as e:
-                    print(f"\nError benchmarking {config_name} @ {resolution}: {e}")
+                except Exception as error:
+                    runtime_errors += 1
+                    print(
+                        f"vit-benchmark failed: {config_name} @ {resolution}: {error}",
+                        file=sys.stderr,
+                    )
 
                 overall_pbar.update(1)
 
     print(f"\nCompleted {len(all_results)} benchmark(s)")
 
     # Save results to CSV
-    csv_path = args.output_dir / "benchmark_results.csv"
-    save_results_to_csv(all_results, csv_path)
-    print(f"Saved results to {csv_path}")
+    if all_results:
+        csv_path = args.output_dir / "benchmark_results.csv"
+        save_results_to_csv(all_results, csv_path)
+        print(f"Saved results to {csv_path}")
 
     # Generate plots
     if not args.no_plots and all_results:
@@ -261,11 +282,17 @@ def main() -> None:
             )
             print(f"  Created throughput plot(s): {', '.join(str(p) for p in paths)}")
 
-        except Exception as e:
-            print(f"Error generating plots: {e}")
+        except Exception as error:
+            runtime_errors += 1
+            print(f"vit-benchmark failed: could not generate plots: {error}", file=sys.stderr)
+
+    if runtime_errors:
+        print(f"vit-benchmark failed: {runtime_errors} runtime error(s)", file=sys.stderr)
+        return 2
 
     print("\nBenchmarking complete!")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -204,6 +204,30 @@ def test_benchmark_memory(small_config: ViTConfig, device: torch.device) -> None
     assert memory_mb >= 0  # May be 0 for CPU
 
 
+def test_backward_memory_excludes_forward_peak(mocker) -> None:
+    """Backward-only memory tracking must reset peak stats after graph construction."""
+    events: list[str] = []
+    model = RecordingModel(events)
+    mocker.patch(
+        "benchmark.benchmark.torch.cuda.reset_peak_memory_stats", side_effect=lambda _device: events.append("reset")
+    )
+    mocker.patch("benchmark.benchmark.torch.cuda.empty_cache", side_effect=lambda: events.append("empty_cache"))
+    mocker.patch(
+        "benchmark.benchmark.torch.cuda.max_memory_allocated",
+        side_effect=lambda _device: events.append("peak") or 0,
+    )
+
+    benchmark_memory(
+        model,
+        torch.ones(1),
+        num_iters=1,
+        pass_mode="backward",
+        device=torch.device("cuda"),
+    )
+
+    assert events == ["forward", "reset", "empty_cache", "backward", "peak"]
+
+
 @pytest.mark.parametrize("pass_mode", ["forward", "backward", "forward_backward"])
 def test_run_full_benchmark(small_config: ViTConfig, device: torch.device, pass_mode: str) -> None:
     """Test full benchmark suite."""

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -5,8 +5,11 @@ from pathlib import Path
 
 import pytest
 import torch
+import torch.nn as nn
 
 from benchmark import (
+    BenchmarkResult,
+    PassMode,
     benchmark_latency,
     benchmark_memory,
     compute_gflops,
@@ -15,7 +18,41 @@ from benchmark import (
     run_full_benchmark,
     warmup_model,
 )
+from benchmark.cli import main as benchmark_cli_main, parse_resolution
 from vit import ViTConfig
+
+
+FORWARD_GFLOPS = 4.0
+SQUARE_RESOLUTION = 224
+SMALL_CONFIG_YAML = """\
+in_channels: 3
+patch_size: [8, 8]
+img_size: [32, 32]
+depth: 2
+hidden_size: 64
+ffn_hidden_size: 128
+num_attention_heads: 4
+dtype: float32
+"""
+
+
+class RecordingModel(nn.Module):
+    """Record forward and backward work relative to benchmark timer calls."""
+
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+        self.events = events
+
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        self.events.append("forward")
+        output = input_tensor * self.weight
+
+        def record_backward(gradient: torch.Tensor) -> None:
+            self.events.append("backward")
+
+        output.register_hook(record_backward)
+        return output
 
 
 @pytest.fixture
@@ -119,6 +156,39 @@ def test_benchmark_latency(small_config: ViTConfig, device: torch.device, pass_m
     assert latency_ms > 0
 
 
+@pytest.mark.parametrize(
+    ("pass_mode", "expected_events"),
+    [
+        ("backward", ["forward", "timer", "backward", "timer"]),
+        ("forward_backward", ["timer", "forward", "backward", "timer"]),
+    ],
+)
+def test_benchmark_latency_times_the_named_workload(
+    mocker,
+    pass_mode: PassMode,
+    expected_events: list[str],
+) -> None:
+    """Backward-only timing excludes graph construction while combined timing includes it."""
+    events: list[str] = []
+    model = RecordingModel(events)
+
+    def record_timer_call() -> float:
+        events.append("timer")
+        return float(events.count("timer"))
+
+    mocker.patch("benchmark.benchmark.time.perf_counter", side_effect=record_timer_call)
+
+    benchmark_latency(
+        model,
+        torch.ones(1),
+        num_iters=1,
+        pass_mode=pass_mode,
+        device=torch.device("cpu"),
+    )
+
+    assert events == expected_events
+
+
 def test_benchmark_memory(small_config: ViTConfig, device: torch.device) -> None:
     """Test memory benchmarking."""
     model = small_config.instantiate(device=device)
@@ -156,6 +226,37 @@ def test_run_full_benchmark(small_config: ViTConfig, device: torch.device, pass_
     assert result.latency_ms > 0
     assert result.memory_mb >= 0
     assert result.gflops > 0
+
+
+@pytest.mark.parametrize(
+    ("pass_mode", "expected_gflops"),
+    [
+        ("forward", FORWARD_GFLOPS),
+        ("backward", FORWARD_GFLOPS * 2),
+        ("forward_backward", FORWARD_GFLOPS * 3),
+    ],
+)
+def test_run_full_benchmark_reports_named_workload_operations(
+    mocker,
+    small_config: ViTConfig,
+    pass_mode: PassMode,
+    expected_gflops: float,
+) -> None:
+    """Reported operation counts match the selected pass workload."""
+    mocker.patch("benchmark.benchmark.warmup_model")
+    mocker.patch("benchmark.benchmark.benchmark_latency", return_value=1.0)
+    mocker.patch("benchmark.benchmark.benchmark_memory", return_value=0.0)
+    mocker.patch("benchmark.benchmark.compute_gflops", return_value=FORWARD_GFLOPS)
+
+    result = run_full_benchmark(
+        config=small_config,
+        batch_size=1,
+        device="cpu",
+        pass_mode=pass_mode,
+        show_progress=False,
+    )
+
+    assert result.gflops == expected_gflops
 
 
 def test_plot_benchmark_results(small_config: ViTConfig, device: torch.device, tmp_path: Path) -> None:
@@ -196,19 +297,8 @@ def test_plot_benchmark_results(small_config: ViTConfig, device: torch.device, t
 
 def test_config_yaml_loading(tmp_path: Path) -> None:
     """Test loading config from YAML."""
-    yaml_content = """
-in_channels: 3
-patch_size: [8, 8]
-img_size: [32, 32]
-depth: 2
-hidden_size: 64
-ffn_hidden_size: 128
-num_attention_heads: 4
-dtype: float32
-"""
-
     yaml_path = tmp_path / "test_config.yaml"
-    yaml_path.write_text(yaml_content)
+    yaml_path.write_text(SMALL_CONFIG_YAML)
 
     config = ViTConfig.from_yaml(yaml_path)
 
@@ -217,3 +307,99 @@ dtype: float32
     assert config.img_size == [32, 32]
     assert config.depth == 2
     assert config.hidden_size == 64
+
+
+def test_parse_resolution_scalar_is_square() -> None:
+    """A scalar resolution follows the documented two-dimensional square form."""
+    assert parse_resolution(str(SQUARE_RESOLUTION)) == (SQUARE_RESOLUTION, SQUARE_RESOLUTION)
+
+
+def test_cli_invalid_device_uses_runtime_error_exit(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An invalid device is a concise runtime error, not a successful empty run."""
+    invalid_device = "invalid-device"
+    exit_code = benchmark_cli_main(
+        [
+            "--configs",
+            "unused.yaml",
+            "--resolutions",
+            str(SQUARE_RESOLUTION),
+            "--device",
+            invalid_device,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert invalid_device not in captured.out
+    assert f"invalid device '{invalid_device}'" in captured.err
+
+
+def test_cli_success_returns_zero_and_writes_primary_report(
+    mocker,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """A successful run emits the report on stdout and returns zero."""
+    config_path = tmp_path / "config.yaml"
+    output_dir = tmp_path / "results"
+    config_path.write_text(SMALL_CONFIG_YAML)
+    mocker.patch(
+        "benchmark.cli.run_full_benchmark",
+        return_value=BenchmarkResult(
+            latency_ms=1.0,
+            memory_mb=0.0,
+            gflops=FORWARD_GFLOPS,
+            config_name="config",
+            batch_size=1,
+            image_size=(32, 32),
+            pass_mode="forward",
+        ),
+    )
+
+    exit_code = benchmark_cli_main(
+        [
+            "--configs",
+            str(config_path),
+            "--resolutions",
+            "32,32",
+            "--output-dir",
+            str(output_dir),
+            "--no-plots",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Completed 1 benchmark(s)" in captured.out
+    assert (output_dir / "benchmark_results.csv").exists()
+
+
+def test_cli_failure_uses_stderr_and_nonzero_exit(
+    mocker,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """A run with no successful cases reports diagnostics separately and fails."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(SMALL_CONFIG_YAML)
+    mocker.patch("benchmark.cli.run_full_benchmark", side_effect=RuntimeError("device failure"))
+
+    exit_code = benchmark_cli_main(
+        [
+            "--configs",
+            str(config_path),
+            "--resolutions",
+            "32,32",
+            "--output-dir",
+            str(tmp_path / "results"),
+            "--no-plots",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "device failure" not in captured.out
+    assert "vit-benchmark failed:" in captured.err
+    assert "device failure" in captured.err


### PR DESCRIPTION
## Motivation

The full-model benchmark measured the same forward-plus-backward workload for both training pass modes even though it reported different operation counts. The command also treated a documented scalar resolution as one-dimensional and returned exit status 0 after every requested case failed. Those behaviors make latency data and automation results unreliable.

Addresses #102.

## Solution

Define the timer boundary for each pass mode, expand scalar inputs to square 2D resolutions, and return explicit CLI status codes. Backward-only now builds its graph before the synchronized timer; `forward_backward` measures graph construction, loss construction, and autograd together. Runtime diagnostics use stderr while the benchmark report and successful case data remain on stdout.

## Changes

- Measure backward-only and combined training workloads with distinct timer boundaries.
- Keep the existing approximate operation multipliers aligned with the measured workloads.
- Reset CUDA peak-memory statistics after backward-only graph construction.
- Interpret `--resolutions 224` as `(224, 224)`.
- Validate device and configuration inputs with concise runtime errors.
- Return exit code 2 when any requested case or plot operation fails, including empty runs.
- Save and report successful cases when another requested case fails.
- Document the three pass-mode contracts.

## Test plan

- [x] `make test-benchmark` (32 passed)
- [x] `make quality`
- [x] `make types`
- [x] `make test-ci` (412 passed, 258 skipped, 6 deselected; 94% production coverage)
- [x] Run `vit-benchmark` with `--device invalid-device` and confirm exit status 2.

## Test suite changes

Added ten parametrized or standalone cases across seven test functions. They cover timer event ordering, operation-count multipliers, scalar resolution expansion, invalid-device handling, successful report output, and all-cases-failed stream and exit behavior. The existing YAML fixture text moved to a shared constant; its assertions and coverage intent did not change.

## Risks

Backward-only measurement still performs an untimed forward pass for each sample because autograd needs a fresh graph. The documented GFLOP multipliers remain estimates rather than profiler-derived counts. No benchmark default or result schema changed.

Generated with Codex.