### PR TITLE
Preserve non-divisible scaled mask shapes

### DIFF
--- a/benchmark/cli.py
+++ b/benchmark/cli.py
@@ -6,6 +6,7 @@ import csv
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import torch
 
@@ -13,6 +14,13 @@ from vit import ViTConfig
 
 
 OPTIONAL_DEPENDENCY_MODULES = {"matplotlib", "tqdm"}
+
+
+def run_full_benchmark(*args: Any, **kwargs: Any) -> Any:
+    """Lazily invoke the full benchmark while preserving the CLI patch point."""
+    from .benchmark import run_full_benchmark as implementation
+
+    return implementation(*args, **kwargs)
 
 
 def parse_resolution(resolution_str: str) -> tuple[int, ...]:
@@ -170,7 +178,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         from tqdm import tqdm
 
-        from .benchmark import run_full_benchmark
         from .plotting import plot_benchmark_results, plot_multi_metric_comparison, plot_throughput_analysis
     except ModuleNotFoundError as error:
         missing_module = error.name.partition(".")[0] if error.name else None

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -8,6 +8,9 @@ from torch.testing import assert_close
 from vit.tokens import apply_mask, create_mask, generate_non_overlapping_mask, mask_is_ragged, unapply_mask
 
 
+NON_DIVISIBLE_SCALE_SEED = 1
+
+
 @pytest.mark.parametrize(
     "mask, exp",
     [
@@ -120,6 +123,13 @@ class TestCreateMask:
             for column in range(0, size[1], scale):
                 block = mask_grid[row : row + scale, column : column + scale]
                 assert (block == block[0, 0]).all()
+
+    def test_non_divisible_scale_has_equal_counts_per_sample(self):
+        """Scaled masks remain non-ragged after cropping partial boundary blocks."""
+        torch.manual_seed(NON_DIVISIBLE_SCALE_SEED)
+        mask = create_mask((5, 5), 0.5, batch_size=2, scale=2)
+
+        assert not mask_is_ragged(mask)
 
     def test_create_device(self):
         size = (16, 16)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -99,6 +101,25 @@ class TestCreateMask:
         # so pooled entries should be all 1.0 or 0.0
         pooled = F.adaptive_avg_pool2d(mask_grid.float(), target_size).view(*target_size)
         assert ((pooled == 1.0) | (pooled == 0.0)).all()
+
+    @pytest.mark.parametrize("size", [(5, 5), (5, 7, 9)])
+    def test_non_divisible_scale_preserves_token_grid_size(self, size):
+        """Scaled masks retain every token in non-divisible 2D and 3D grids."""
+        batch_size = 2
+        mask = create_mask(size, 0.5, batch_size=batch_size, scale=2)
+
+        assert mask.shape == (batch_size, math.prod(size))
+
+    def test_non_divisible_scale_keeps_boundary_blocks_contiguous(self):
+        """Cropped boundary blocks retain the requested maximum block width."""
+        size = (5, 5)
+        scale = 2
+        mask_grid = create_mask(size, 0.5, scale=scale).view(*size)
+
+        for row in range(0, size[0], scale):
+            for column in range(0, size[1], scale):
+                block = mask_grid[row : row + scale, column : column + scale]
+                assert (block == block[0, 0]).all()
 
     def test_create_device(self):
         size = (16, 16)

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -454,6 +454,30 @@ class TestViT:
         L = math.prod(model.stem.tokenized_size(config.img_size))
         assert out.visual_tokens.shape == (2, L // 2, 128)
 
+    @pytest.mark.parametrize("token_grid_size", [(5, 5), (5, 5, 5)])
+    def test_forward_with_non_divisible_scaled_mask(self, device, token_grid_size):
+        """Every scaled mask returned by the model fits its tokenized input."""
+        patch_size = (4,) * len(token_grid_size)
+        config = ViTConfig(
+            in_channels=3,
+            patch_size=patch_size,
+            img_size=tuple(grid * patch for grid, patch in zip(token_grid_size, patch_size)),
+            depth=1,
+            hidden_size=8,
+            ffn_hidden_size=16,
+            num_attention_heads=2,
+            pos_enc="learnable",
+            dtype=torch.float32,
+        )
+        model = ViT(config).to(device)
+        input_tensor = torch.randn(1, config.in_channels, *config.img_size, device=device)
+
+        mask = model.create_mask(input_tensor, unmasked_ratio=0.5, scale=2)
+        output = model(input_tensor, mask=mask)
+
+        assert mask.shape == (1, math.prod(token_grid_size))
+        assert output.visual_tokens.shape[1] == mask.sum()
+
     @pytest.mark.parametrize("num_register_tokens", [0, 2])
     def test_backward(self, device, config, num_register_tokens):
         config = replace(config, num_register_tokens=num_register_tokens)

--- a/vit/tokens.py
+++ b/vit/tokens.py
@@ -143,11 +143,13 @@ def create_mask(
 
     # When scale > 1, reformulate the problem as a recursive call over smaller mask and upsample
     if scale > 1:
-        scaled_size = tuple(s // scale for s in size)
+        scaled_size = tuple((dimension + scale - 1) // scale for dimension in size)
         mask = create_mask(scaled_size, mask_ratio, batch_size, scale=1, device=device)
         mask = mask.view(batch_size, 1, *scaled_size).float()
         mask = F.interpolate(mask, scale_factor=scale, mode="nearest")
-        mask = mask.view(batch_size, -1).bool()
+        spatial_slices = tuple(slice(dimension) for dimension in size)
+        mask = mask[(slice(None), slice(None), *spatial_slices)]
+        mask = mask.reshape(batch_size, -1).bool()
 
         # roll the mask (rolling is only defined for scale > 1)
         if roll:

--- a/vit/tokens.py
+++ b/vit/tokens.py
@@ -103,6 +103,40 @@ def unapply_mask(mask: Tensor, x: Tensor) -> Tensor:
     return result
 
 
+def _scaled_block_volumes(size: Sequence[int], scaled_size: Sequence[int], scale: int, device: torch.device) -> Tensor:
+    """Return the expanded token count for each cell in a cropped coarse grid."""
+    block_volumes = torch.ones(tuple(scaled_size), dtype=torch.long, device=device)
+    dimensions = len(scaled_size)
+
+    for axis, (dimension, scaled_dimension) in enumerate(zip(size, scaled_size, strict=True)):
+        axis_lengths = torch.full((scaled_dimension,), scale, dtype=torch.long, device=device)
+        axis_lengths[-1] = dimension - scale * (scaled_dimension - 1)
+        axis_shape = [1] * dimensions
+        axis_shape[axis] = scaled_dimension
+        block_volumes *= axis_lengths.view(axis_shape)
+
+    return block_volumes.flatten()
+
+
+def _create_equal_volume_mask(block_volumes: Tensor, mask_ratio: float, batch_size: int) -> Tensor:
+    """Create independent coarse masks with equal expanded token counts."""
+    coarse_tokens = block_volumes.numel()
+    masked_tokens = int(torch.tensor(coarse_tokens * mask_ratio).round().item())
+    random_scores = torch.rand((batch_size, coarse_tokens), device=block_volumes.device)
+    reference_masked_indices = random_scores[0].argsort()[:masked_tokens]
+    reference_masked_volumes = block_volumes[reference_masked_indices]
+    mask = torch.ones((batch_size, coarse_tokens), dtype=torch.bool, device=block_volumes.device)
+
+    for block_volume in block_volumes.unique():
+        group_indices = torch.where(block_volumes == block_volume)[0]
+        group_masked_tokens = int((reference_masked_volumes == block_volume).sum().item())
+        group_rankings = random_scores[:, group_indices].argsort(dim=-1)
+        masked_indices = group_indices[group_rankings[:, :group_masked_tokens]]
+        mask.scatter_(1, masked_indices, False)
+
+    return mask
+
+
 def create_mask(
     size: Sequence[int],
     mask_ratio: float,
@@ -144,7 +178,8 @@ def create_mask(
     # When scale > 1, reformulate the problem as a recursive call over smaller mask and upsample
     if scale > 1:
         scaled_size = tuple((dimension + scale - 1) // scale for dimension in size)
-        mask = create_mask(scaled_size, mask_ratio, batch_size, scale=1, device=device)
+        block_volumes = _scaled_block_volumes(size, scaled_size, scale, device)
+        mask = _create_equal_volume_mask(block_volumes, mask_ratio, batch_size)
         mask = mask.view(batch_size, 1, *scaled_size).float()
         mask = F.interpolate(mask, scale_factor=scale, mode="nearest")
         spatial_slices = tuple(slice(dimension) for dimension in size)


### PR DESCRIPTION
## Motivation

`create_mask()` used floor division for its coarse grid and then restored each dimension with a fixed scale factor. A 5 by 5 grid at scale 2 therefore returned 16 mask elements instead of 25, and `ViT.forward()` rejected the mask because it did not match the patch-token sequence.

Addresses #103.

## Solution

Build the coarse mask with ceiling division, expand it into full-size contiguous blocks, and crop only the excess cells at each spatial boundary. For batched non-divisible grids, sample each row independently while keeping the same selected-block quota for every expanded block volume. The final masks therefore have the exact requested shape and equal retained-token counts across the batch.

## Changes

- Use ceiling-sized coarse grids for scaled mask generation.
- Preserve exact `scale`-wide interior blocks and truncate only boundary blocks.
- Return exactly `math.prod(size)` mask elements for non-divisible grids.
- Keep batched scaled masks non-ragged by matching selected-block quotas by expanded volume.
- Add direct 2D and 3D shape, block-contiguity, and batched token-count tests.
- Add end-to-end 2D and 3D `ViT.create_mask()` and `ViT.forward()` coverage.
- Preserve the lazy `benchmark.cli.run_full_benchmark` patch point after integrating the merged benchmark PRs.

## Test plan

- [x] Regression first: `pytest tests/test_tokens.py::TestCreateMask::test_non_divisible_scale_has_equal_counts_per_sample -q` (failed before the fix, then passed)
- [x] `pytest tests/test_tokens.py -q` (42 passed)
- [x] `make check` (740 passed, 5 skipped; 95% production coverage)
- [x] `make test-ci` (457 passed, 282 skipped, 6 deselected; 94% production coverage)

## Test suite changes

Added direct coverage for non-divisible 2D and 3D mask shapes, boundary-block contiguity, equal retained-token counts across batched masks, and model consumption for 2D and 3D inputs on CPU and CUDA when available. The merged CLI regression suite also verifies the lazy benchmark patch point. No existing tests were removed or materially altered.

## Risks

Non-divisible grids end with smaller boundary blocks. The sampler shares only the selected-block count for each expanded-volume group across a batch; block positions remain independently randomized. This keeps sequence lengths equal across samples, while the exact masked-token ratio can still vary between calls because boundary blocks contain fewer tokens.

Generated with Codex.