### PR TITLE
Reject unsupported YAML dtypes

### DIFF
--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -24,6 +24,12 @@ HEAD_FACTORY_CASES = (
 FACTORY_OVERRIDE_DTYPE = torch.float32
 FACTORY_CONFIG_DTYPE = torch.bfloat16
 TORCHAO_QUANTIZATION_CONFIG_VERSION = 2
+SUPPORTED_YAML_DTYPES = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "float64": torch.float64,
+}
 
 
 @pytest.fixture(params=[pytest.param(False, id="2d"), pytest.param(True, id="3d")])
@@ -363,6 +369,26 @@ class TestViT:
             f.write(config.to_yaml())
         config_from_path = ViTConfig.from_yaml(path)
         assert config == config_from_path
+
+    def test_config_from_yaml_rejects_unsupported_dtype(self, config):
+        """A dtype typo fails during configuration loading."""
+        config_yaml = config.to_yaml()
+        assert "dtype: float32" in config_yaml
+
+        with pytest.raises(ValueError, match=r"Unsupported dtype 'float23'.*bfloat16.*float64"):
+            ViTConfig.from_yaml(config_yaml.replace("dtype: float32", "dtype: float23"))
+
+    @pytest.mark.parametrize(("dtype_name", "dtype"), SUPPORTED_YAML_DTYPES.items())
+    def test_config_yaml_dtype_roundtrip_controls_parameters(self, config, dtype_name, dtype):
+        """Every serialized dtype round-trips and controls instantiated parameters."""
+        config_yaml = replace(config, depth=0, dtype=dtype).to_yaml()
+
+        loaded_config = ViTConfig.from_yaml(config_yaml)
+        model = loaded_config.instantiate()
+
+        assert f"dtype: {dtype_name}" in config_yaml
+        assert loaded_config.dtype == dtype
+        assert model.stem.patch.weight.dtype == dtype
 
     def test_config_from_yaml_with_attentive_pool_head(self, config):
         config_with_head = replace(config, heads={"cls": AttentivePoolHeadConfig(out_features=32, num_queries=2)})

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -31,19 +31,21 @@ from .transformer import CrossAttentionTransformer, TransformerDecoderLayer, Tra
 
 HeadConfigType = HeadConfig | AttentivePoolHeadConfig | TransposedConv2dHeadConfig | UpsampleHeadConfig
 HeadModuleType = Head | AttentivePoolHead | TransposedConv2dHead | UpsampleHead
+_DTYPE_BY_NAME = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+    "float64": torch.float64,
+}
 
 
-def _parse_dtype(dtype_str: str | None) -> torch.dtype | None:
+def _parse_dtype(dtype_str: str) -> torch.dtype:
     """Convert string dtype representation to torch.dtype."""
-    if dtype_str is None:
-        return None
-    dtype_map = {
-        "float32": torch.float32,
-        "float16": torch.float16,
-        "bfloat16": torch.bfloat16,
-        "float64": torch.float64,
-    }
-    return dtype_map.get(dtype_str, None)
+    try:
+        return _DTYPE_BY_NAME[dtype_str]
+    except KeyError:
+        supported_dtypes = ", ".join(sorted(_DTYPE_BY_NAME))
+        raise ValueError(f"Unsupported dtype {dtype_str!r}. Expected one of: {supported_dtypes}") from None
 
 
 def vit_config_constructor(loader, node):


### PR DESCRIPTION
## Motivation

An unknown serialized dtype such as `float23` was converted to `None`. Model construction then used PyTorch's default float32 parameters, so the loaded model did not match the recorded configuration and no error identified the typo.

Addresses #104.

## Solution

Resolve serialized dtype names through one explicit mapping and raise during YAML loading when a name is not supported. The error includes the rejected value and every accepted name.

## Changes

- Replace the silent dictionary fallback with strict dtype lookup.
- List `bfloat16`, `float16`, `float32`, and `float64` in unsupported-value errors.
- Verify each accepted name through YAML serialization, loading, and model instantiation.
- Cover invalid values for both 2D and 3D configurations.

## Test plan

- [x] `make test-yaml` (20 passed)
- [x] `make quality`
- [x] `make types`
- [x] `make test-ci` (412 passed, 258 skipped, 6 deselected; 94% production coverage)

## Test suite changes

Added ten parametrized cases across two test functions. Two cases reject an unsupported dtype in 2D and 3D configurations; eight cases round-trip all four supported names and verify the instantiated stem parameter dtype. No existing tests were removed or materially altered.

## Risks

YAML files that previously relied on an unsupported dtype silently becoming float32 now fail during loading. Supported dtype names and defaults are unchanged.

Generated with Codex.