### PR TITLE
Add standing dependency vulnerability audits

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,41 @@
+name: Dependency audit
+
+"on":
+  pull_request:
+    paths:
+      - .github/workflows/dependency-audit.yml
+      - Makefile
+      - pyproject.toml
+      - uv.lock
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/dependency-audit.yml
+      - Makefile
+      - pyproject.toml
+      - uv.lock
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.14"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install uv
+        run: python -m pip install "uv==0.11.28"
+      - name: Audit locked dependencies
+        run: make audit-dependencies PYTHON_VERSION="${{ matrix.python-version }}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-env check quality style tag-version test env upload upload-test
+.PHONY: audit-dependencies clean clean-env check quality style tag-version test env upload upload-test
 
 PROJECT=vit
 QUALITY_DIRS=$(PROJECT) tests benchmark
@@ -7,6 +7,9 @@ UV_VERSION=0.11.28
 UVX=uvx
 UV=$(UVX) --from uv==$(UV_VERSION) uv
 PYTHON=$(UV) run python
+PIP_AUDIT_VERSION=2.10.1
+PIP_AUDIT=$(UVX) --python $(PYTHON_VERSION) --from pip-audit==$(PIP_AUDIT_VERSION) pip-audit
+PYTHON_VERSION?=3.14
 
 CONFIG_FILE := config.mk
 ifneq ($(wildcard $(CONFIG_FILE)),)
@@ -18,6 +21,26 @@ check: ## run quality checks and unit tests
 	$(MAKE) quality
 	$(MAKE) types
 	$(MAKE) test
+
+audit-dependencies: ## audit locked Python dependencies for known public vulnerabilities
+	@audit_directory="$$(mktemp -d)"; \
+	requirements_file="$$audit_directory/requirements.txt"; \
+	trap 'rm -rf "$$audit_directory"' EXIT; \
+	$(UV) export \
+		--frozen \
+		--all-groups \
+		--no-emit-project \
+		--quiet \
+		--python "$(PYTHON_VERSION)" \
+		--output-file "$$requirements_file"; \
+	$(PIP_AUDIT) \
+		--strict \
+		--disable-pip \
+		--require-hashes \
+		--cache-dir "$$audit_directory/cache" \
+		--progress-spinner=off \
+		--vulnerability-service pypi \
+		--requirement "$$requirements_file"
 
 clean: ## remove cache files
 	find $(CLEAN_DIRS) -path '*/__pycache__/*' -delete

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ check: ## run quality checks and unit tests
 	$(MAKE) test
 
 audit-dependencies: ## audit locked Python dependencies for known public vulnerabilities
-	@audit_directory="$$(mktemp -d)"; \
+	@set -e; \
+	audit_directory="$$(mktemp -d)"; \
 	requirements_file="$$audit_directory/requirements.txt"; \
 	trap 'rm -rf "$$audit_directory"' EXIT; \
 	$(UV) export \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security
+
+## Dependency audits
+
+Run the public-vulnerability audit against both supported Python bounds:
+
+```console
+make audit-dependencies PYTHON_VERSION=3.11
+make audit-dependencies PYTHON_VERSION=3.14
+```
+
+The target exports every locked dependency group from `uv.lock`, omits the local project, and passes the pinned
+requirements to `pip-audit`. A known public vulnerability makes the command fail. GitHub Actions runs the same checks
+when dependency inputs change, on updates to `master`, on manual request, and every Monday.
+
+No vulnerability IDs are ignored. Any future `--ignore-vuln` entry must identify the affected package, explain why the
+advisory does not apply, link to supporting evidence, and include a review date in this file.
+
+## Coverage
+
+| Surface | Coverage decision |
+| --- | --- |
+| Direct and transitive Python packages | Audited from all locked groups for Python 3.11 and 3.14 on Linux. |
+| Public vulnerability data | `pip-audit==2.10.1` queries PyPI's public vulnerability service. |
+| Project source | Not covered by `pip-audit`; formatting, linting, typing, and tests remain separate quality gates. |
+| Native libraries bundled inside wheels | Not covered unless the vulnerability is reported against the Python package. Review upstream package advisories during dependency updates. |
+| Non-Linux dependency variants | Not covered by the scheduled audit because the supported CI environment is Linux. Review platform-specific changes when adding another CI platform. |
+| CircleCI images and the Codecov orb | Not covered by `pip-audit`. Review their release and security notices when changing the versioned CI references. |
+| GitHub Actions | `actions/checkout` is pinned to a full commit SHA. Review the upstream release before changing it. |

--- a/benchmark/cli.py
+++ b/benchmark/cli.py
@@ -6,6 +6,7 @@ import csv
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import torch
 
@@ -13,6 +14,13 @@ from vit import ViTConfig
 
 
 OPTIONAL_DEPENDENCY_MODULES = {"matplotlib", "tqdm"}
+
+
+def run_full_benchmark(*args: Any, **kwargs: Any) -> Any:
+    """Lazily invoke the full benchmark while preserving the CLI patch point."""
+    from .benchmark import run_full_benchmark as implementation
+
+    return implementation(*args, **kwargs)
 
 
 def parse_resolution(resolution_str: str) -> tuple[int, ...]:
@@ -170,7 +178,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         from tqdm import tqdm
 
-        from .benchmark import run_full_benchmark
         from .plotting import plot_benchmark_results, plot_multi_metric_comparison, plot_throughput_analysis
     except ModuleNotFoundError as error:
         missing_module = error.name.partition(".")[0] if error.name else None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,43 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).parents[1]
+DEPENDENCY_AUDIT_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "dependency-audit.yml"
+SUPPORTED_PYTHON_BOUNDS = {"3.11", "3.14"}
+
+
+def test_dependency_audit_workflow_is_scheduled_and_covers_supported_python_bounds() -> None:
+    workflow = yaml.safe_load(DEPENDENCY_AUDIT_WORKFLOW.read_text())
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["on"]["schedule"]
+    assert set(workflow["jobs"]["audit"]["strategy"]["matrix"]["python-version"]) == SUPPORTED_PYTHON_BOUNDS
+
+
+def test_dependency_audit_target_runs_scanner_on_requested_python() -> None:
+    result = subprocess.run(
+        ["make", "--dry-run", "audit-dependencies", "PYTHON_VERSION=3.11"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "uvx --python 3.11 --from pip-audit==2.10.1 pip-audit" in result.stdout
+
+
+@pytest.mark.parametrize(("scanner", "should_succeed"), [("true", True), ("false", False)])
+def test_dependency_audit_target_propagates_scanner_status(scanner: str, should_succeed: bool) -> None:
+    result = subprocess.run(
+        ["make", "audit-dependencies", "UV=true", f"PIP_AUDIT={scanner}"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert (result.returncode == 0) is should_succeed, result.stderr

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -41,3 +41,16 @@ def test_dependency_audit_target_propagates_scanner_status(scanner: str, should_
     )
 
     assert (result.returncode == 0) is should_succeed, result.stderr
+
+
+def test_dependency_audit_target_propagates_export_failure() -> None:
+    """The scanner must not mask a failed locked-dependency export."""
+    result = subprocess.run(
+        ["make", "audit-dependencies", "UV=false", "PIP_AUDIT=true"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0


### PR DESCRIPTION
## Motivation

The lockfile pins production, benchmark, development, and test dependencies, but the repository had no recurring check for newly published public vulnerabilities. The point-in-time audit in issue #105 was clean and did not detect advisories published after that run.

Addresses #105.

## Solution

Add one pinned Make target that exports every locked dependency group with hashes and runs `pip-audit` under the requested Python interpreter. A GitHub Actions matrix runs the same command at the supported Python bounds on dependency changes, updates to `master`, manual dispatch, and a weekly schedule.

## Changes

- Add `make audit-dependencies PYTHON_VERSION=<version>`.
- Pin `pip-audit==2.10.1` and evaluate environment markers under Python 3.11 and 3.14.
- Preserve dependency-export and scanner failure status so incomplete or known-vulnerable audits fail the job.
- Add an isolated temporary requirements file and audit cache for concurrent runs.
- Add a scheduled GitHub Actions workflow with read-only repository permissions.
- Document covered dependency surfaces, exclusions, and future suppression evidence in `SECURITY.md`.
- Preserve the lazy `benchmark.cli.run_full_benchmark` patch point while synchronizing the merged benchmark changes.

## Test plan

- [x] `make audit-dependencies PYTHON_VERSION=3.11`
- [x] `make audit-dependencies PYTHON_VERSION=3.14`
- [x] `make quality`
- [x] `make types`
- [x] `make check-distribution`
- [x] `make test-ci` (456 passed, 280 skipped, 6 deselected; 94% production coverage)
- [x] GitHub Actions audit matrix passed for Python 3.11 and 3.14.

Both live audits reported no known vulnerabilities.

## Test suite changes

Added four security-configuration test functions, producing five pytest cases. They verify the scheduled Python-version matrix, target-interpreter selection, and propagation of both clean and failing scanner statuses. No existing tests were removed or materially altered.

## Risks

The scanner covers public advisories attached to Python package metadata. It does not scan native libraries inside wheels, non-Linux variants, CircleCI images, or the Codecov orb; `SECURITY.md` records those exclusions. The scheduled job depends on PyPI and the public vulnerability service being reachable.

Generated with Codex.