### PR TITLE
Add ViT explainability toolbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,9 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Core library code lives in `vit/` (for example `vit/vit.py`, `vit/attention.py`, `vit/transformer.py`).  
+Core library code lives in `vit/` (for example `vit/vit.py`, `vit/attention.py`, `vit/transformer.py`).
+The Python-first explainability toolbox lives in `vit/explain/`; its sparse autoencoder remains isolated under
+`vit/explain/experimental/`.
 Unit tests live in `tests/` and follow module-level coverage (`tests/test_vit.py`, `tests/test_attention.py`, etc.).  
 Benchmark tooling and CLI entrypoints live in `benchmark/`; generated benchmark outputs are typically written to
 `benchmark_results/`.  
@@ -11,9 +13,23 @@ Build metadata and tooling configuration are in `pyproject.toml`, `Makefile`, an
 Main flow is `Images -> PatchEmbed -> Transformer -> ViTFeatures -> Heads`.
 
 - `ViT.forward()` returns a `ViTFeatures` dataclass (not a raw tensor).
-- No CLS token is used; pooling/classification behavior is implemented in heads.
+- CLS and register tokens are optional. Pooling and classification behavior remains explicit in heads.
 - Prefer config-driven construction via `ViTConfig.instantiate()` and `HeadConfig.instantiate()`.
 - Use `activation_checkpointing=True` in `ViTConfig` when trading latency for lower training memory.
+
+### Explainability architecture
+
+- Stable explainability supports the native repository `ViT` on 2D inputs. Reject 3D inputs with an actionable error.
+- Keep normal inference on the fused path. Capture graph-connected attention probabilities only through the eager
+  trace path in `vit/explain/trace.py`.
+- Preserve caller-owned training flags, parameter gradient flags, and existing gradients around explanation calls.
+- Route masks, RoPE seeds, output-norm choices, and conditioning through `ForwardArgs` on every explanatory forward.
+- Keep raw attribution values unnormalized. Put interpolation and normalization in explicit visualization functions.
+- Treat raw attention and attention rollout as query-selected structure, not class attribution or causal evidence.
+- Add new attribution algorithms through `AttributionMethod`; do not branch on method names in `ViTExplainer`.
+- Keep Captum and plotting imports lazy so core imports and `vit-explain --help` work without the explainability extra.
+- Store explanation arrays as non-pickle NPZ plus deterministic JSON metadata. Do not include images or model weights.
+- Run `make test-explain` after explainability changes, followed by `make check` before handoff.
 
 ## Build, Test, and Development Commands
 Use `uv` and Make targets to keep local and CI behavior aligned.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: audit-dependencies check-distribution clean clean-env check quality style tag-version test env upload upload-test
 
 PROJECT=vit
-QUALITY_DIRS=$(PROJECT) tests benchmark tools
-CLEAN_DIRS=$(PROJECT) tests benchmark tools
+QUALITY_DIRS=$(PROJECT) tests benchmark tools examples
+CLEAN_DIRS=$(PROJECT) tests benchmark tools examples
 UV_VERSION=0.11.28
 UVX=uvx
 UV=$(UVX) --from uv==$(UV_VERSION) uv

--- a/README.md
+++ b/README.md
@@ -79,12 +79,15 @@ print(explanation.token_attributions.shape)
 print(explanation.layout.visual_validity)
 ```
 
-LeGrad is the recommended class-specific ViT method. Raw attention and attention rollout require an explicit query
-selector because they describe attention structure, not a class prediction. Attribution arrays remain unnormalized;
-normalization and image interpolation are separate visualization operations.
+LeGrad is the recommended class-specific ViT method and is based on
+[Bousselham et al. (ICCV 2025)](https://openaccess.thecvf.com/content/ICCV2025/html/Bousselham_LeGrad_An_Explainability_Method_for_Vision_Transformers_via_Feature_Formation_ICCV_2025_paper.html).
+Raw attention and attention rollout require an explicit query selector because they describe attention structure, not
+a class prediction. Attribution arrays remain unnormalized; normalization and image interpolation are separate
+visualization operations.
 
 See [`docs/explainability.md`](docs/explainability.md) for methods, targets, masking, interventions, metrics,
-artifacts, and the experimental sparse autoencoder. Run the synthetic example with:
+artifacts, the experimental sparse autoencoder, and a method-by-method citation guide. Copy-ready references are in
+[`docs/explainability-references.bib`](docs/explainability-references.bib). Run the synthetic example with:
 
 ```bash
 uv run python examples/explain_synthetic.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ViT
 
 Implementation of Vision Transformer (ViT) in native PyTorch, accelerated by `torch.compile`.
-Supports modern enhancements like RMSNorm, SwiGLU, Squared ReLU, register tokens, and different positional encodings. This implementation does not incorporate a `CLS` token.
+Supports RMSNorm, SwiGLU, Squared ReLU, optional CLS and register tokens, and several positional encodings.
 
 Transformer residual output projections are zero-initialized by default (`attn out_proj` and `mlp fc2`) for stable deep-stack initialization.
 
@@ -17,6 +17,12 @@ For benchmarking capabilities, install with the benchmarking extras:
 
 ```bash
 pip install "vit[benchmarking] @ git+https://github.com/TidalPaladin/vit.git"
+```
+
+Install Captum and artifact-rendering dependencies for the explainability toolbox:
+
+```bash
+pip install "vit[explainability] @ git+https://github.com/TidalPaladin/vit.git"
 ```
 
 ## Usage
@@ -57,6 +63,33 @@ features = model(x)
 logits = model.heads["cls"](features.visual_tokens)  # B, 10
 ```
 
+## Explainability
+
+`vit.explain` traces the native 2D `ViT`, attributes selected outputs, runs causal interventions, and evaluates
+explanations. The caller supplies the downstream prediction through `output_fn`; the toolbox never guesses how a
+plain linear head should pool tokens.
+
+```python
+from vit.explain import LeGrad, ViTExplainer
+
+explainer = ViTExplainer.from_head(model, "cls")
+explanation = explainer.attribute(x, target=3, method=LeGrad())
+
+print(explanation.token_attributions.shape)
+print(explanation.layout.visual_validity)
+```
+
+LeGrad is the recommended class-specific ViT method. Raw attention and attention rollout require an explicit query
+selector because they describe attention structure, not a class prediction. Attribution arrays remain unnormalized;
+normalization and image interpolation are separate visualization operations.
+
+See [`docs/explainability.md`](docs/explainability.md) for methods, targets, masking, interventions, metrics,
+artifacts, and the experimental sparse autoencoder. Run the synthetic example with:
+
+```bash
+uv run python examples/explain_synthetic.py
+```
+
 ## Activation Checkpointing
 
 Enable activation checkpointing to reduce memory usage during training at the cost of additional compute:
@@ -85,7 +118,7 @@ uv run python -m benchmark.checkpoint_memory --depths 12 24 --hidden-sizes 768 -
 
 ## Benchmarking
 
-The library includes a comprehensive benchmarking suite for measuring model performance:
+The library includes benchmarks for latency, peak memory, and floating-point operations:
 
 ```bash
 # Install benchmarking dependencies

--- a/docs/codebase-review-notes.md
+++ b/docs/codebase-review-notes.md
@@ -63,3 +63,10 @@ storage dtype.
 Helpers that combine independently constructed PyTorch modules cannot assume their parameters share a device.
 Choose which module owns the computation, transfer inputs at that boundary, and return outputs on the device required
 by the caller. Cover both the common same-device path and at least one deliberate mismatch in tests.
+
+## Record provenance and implementation differences for named algorithms
+
+An API that uses a published algorithm's name can still differ in its propagation rule, spatial domain, sampling
+scheme, or randomization procedure. Documentation and artifact metadata should record both the primary source and the
+local differences so downstream users do not report an adaptation as an exact reproduction. Machine-readable method
+metadata should include a stable variant identifier when two implementations share the same broad method name.

--- a/docs/codebase-review-notes.md
+++ b/docs/codebase-review-notes.md
@@ -1,0 +1,65 @@
+# Codebase correctness review notes
+
+This file records cross-cutting correctness observations found during review. It intentionally omits defects that
+apply to only one method or test fixture.
+
+## Validate compatibility at public API boundaries
+
+APIs that combine model inputs with derived objects should verify semantic compatibility before computing a result.
+Shape checks alone do not detect mismatched image geometry, token masks, prefix-token counts, or modeled crops.
+Centralizing these checks around the existing token-layout representation would give attribution, evaluation,
+visualization, intervention, and artifact paths the same failure behavior.
+
+## Keep padding validity attached to sequence tensors
+
+Ragged masks create padded sequence positions that have the same tensor shape and dtype as modeled tokens. Any code
+that reconstructs, aggregates, scans, or replaces sequence activations should consume the corresponding validity
+mask. A shared helper for selecting valid visual tokens and restoring them to sequence form would reduce the chance
+that a new analysis path treats padding as model data. When token data is projected into pixel space, propagate the
+same validity through masked patches and ignored image borders before aggregating it.
+
+## Define one dataset batch protocol for auxiliary model inputs
+
+Dataset-level tools need sample IDs and may also need per-batch masks, conditioning tensors, or deterministic forward
+arguments. A typed batch adapter should extract these fields together instead of passing one fixed `ForwardArgs`
+object across an entire loader. This would keep activation scans and future streaming analyses aligned with ordinary
+model forwards when auxiliary inputs vary by example.
+
+## Separate spatial geometry from batch-specific token validity
+
+Grid size, patch size, modeled crop, and original image size are batch-invariant for many scans. Visual indices and
+validity masks are batch-specific. Storing both concerns in one layout object is useful for a single explanation, but
+dataset summaries should retain shared geometry separately from the first batch's token mapping.
+
+## Preserve provenance when tensor payloads are omitted
+
+Some tensor-valued settings are too large or sensitive to store in routine artifacts. A metadata sanitizer should
+still record that the tensor was supplied, along with safe fields such as shape, dtype, and a caller-provided label.
+Silently deleting the setting makes two computations with different inputs look as if they used the same
+configuration.
+
+## Register stateful modules accepted by convenience adapters
+
+An adapter that accepts an arbitrary callable should detect `torch.nn.Module` instances and include them in the same
+state-preservation scope as the model. Otherwise repeated analysis forwards can run an external module in training
+mode or update its buffers even though the surrounding API promises deterministic evaluation behavior.
+
+## Normalize parser failures at trust boundaries
+
+File-format libraries often raise exceptions outside the small set documented by their top-level load function.
+Artifact and CLI boundaries should translate the parser's complete malformed-input exception family into one stable,
+user-facing error and exit status. Corrupt archives are useful fixtures because they exercise failures before schema
+validation begins.
+
+## Convert storage dtypes at external library boundaries
+
+Internal tensor and artifact formats can support dtypes that downstream libraries do not. Before passing arrays to
+NumPy, plotting libraries, image encoders, or other consumers, convert them to an explicitly supported interchange
+dtype. Round-trip tests alone do not cover this boundary; each external consumer needs a fixture for every promised
+storage dtype.
+
+## Make cross-module device ownership explicit
+
+Helpers that combine independently constructed PyTorch modules cannot assume their parameters share a device.
+Choose which module owns the computation, transfer inputs at that boundary, and return outputs on the device required
+by the caller. Cover both the common same-device path and at least one deliberate mismatch in tests.

--- a/docs/explainability-references.bib
+++ b/docs/explainability-references.bib
@@ -1,0 +1,230 @@
+@inproceedings{vaswani2017attention,
+  author = {Vaswani, Ashish and Shazeer, Noam and Parmar, Niki and Uszkoreit, Jakob and Jones, Llion and Gomez, Aidan N. and Kaiser, Lukasz and Polosukhin, Illia},
+  title = {Attention Is All You Need},
+  booktitle = {Advances in Neural Information Processing Systems},
+  volume = {30},
+  year = {2017},
+  url = {https://arxiv.org/abs/1706.03762},
+}
+
+@inproceedings{abnar2020attentionflow,
+  author = {Abnar, Samira and Zuidema, Willem},
+  title = {Quantifying Attention Flow in Transformers},
+  booktitle = {Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics},
+  pages = {4190--4197},
+  publisher = {Association for Computational Linguistics},
+  year = {2020},
+  doi = {10.18653/v1/2020.acl-main.385},
+  url = {https://aclanthology.org/2020.acl-main.385/},
+}
+
+@inproceedings{chefer2021transformer,
+  author = {Chefer, Hila and Gur, Shir and Wolf, Lior},
+  title = {Transformer Interpretability Beyond Attention Visualization},
+  booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition},
+  pages = {782--791},
+  year = {2021},
+  url = {https://openaccess.thecvf.com/content/CVPR2021/html/Chefer_Transformer_Interpretability_Beyond_Attention_Visualization_CVPR_2021_paper.html},
+}
+
+@inproceedings{bousselham2025legrad,
+  author = {Bousselham, Walid and Boggust, Angie and Chaybouti, Sofian and Strobelt, Hendrik and Kuehne, Hilde},
+  title = {{LeGrad}: An Explainability Method for Vision Transformers via Feature Formation Sensitivity},
+  booktitle = {Proceedings of the IEEE/CVF International Conference on Computer Vision},
+  pages = {20336--20345},
+  year = {2025},
+  url = {https://openaccess.thecvf.com/content/ICCV2025/html/Bousselham_LeGrad_An_Explainability_Method_for_Vision_Transformers_via_Feature_Formation_ICCV_2025_paper.html},
+}
+
+@inproceedings{selvaraju2017gradcam,
+  author = {Selvaraju, Ramprasaath R. and Cogswell, Michael and Das, Abhishek and Vedantam, Ramakrishna and Parikh, Devi and Batra, Dhruv},
+  title = {{Grad-CAM}: Visual Explanations from Deep Networks via Gradient-Based Localization},
+  booktitle = {Proceedings of the IEEE International Conference on Computer Vision},
+  pages = {618--626},
+  year = {2017},
+  url = {https://openaccess.thecvf.com/content_iccv_2017/html/Selvaraju_Grad-CAM_Visual_Explanations_ICCV_2017_paper.html},
+}
+
+@inproceedings{simonyan2014saliency,
+  author = {Simonyan, Karen and Vedaldi, Andrea and Zisserman, Andrew},
+  title = {Deep Inside Convolutional Networks: Visualising Image Classification Models and Saliency Maps},
+  booktitle = {International Conference on Learning Representations, Workshop Track},
+  year = {2014},
+  url = {https://arxiv.org/abs/1312.6034},
+}
+
+@inproceedings{shrikumar2017deeplift,
+  author = {Shrikumar, Avanti and Greenside, Peyton and Kundaje, Anshul},
+  title = {Learning Important Features Through Propagating Activation Differences},
+  booktitle = {Proceedings of the 34th International Conference on Machine Learning},
+  series = {Proceedings of Machine Learning Research},
+  volume = {70},
+  pages = {3145--3153},
+  publisher = {PMLR},
+  year = {2017},
+  url = {https://proceedings.mlr.press/v70/shrikumar17a.html},
+}
+
+@inproceedings{ancona2018gradient,
+  author = {Ancona, Marco and Ceolini, Enea and {\"O}ztireli, Cengiz and Gross, Markus},
+  title = {Towards Better Understanding of Gradient-Based Attribution Methods for Deep Neural Networks},
+  booktitle = {International Conference on Learning Representations},
+  year = {2018},
+  url = {https://arxiv.org/abs/1711.06104},
+}
+
+@inproceedings{sundararajan2017integrated,
+  author = {Sundararajan, Mukund and Taly, Ankur and Yan, Qiqi},
+  title = {Axiomatic Attribution for Deep Networks},
+  booktitle = {Proceedings of the 34th International Conference on Machine Learning},
+  series = {Proceedings of Machine Learning Research},
+  volume = {70},
+  pages = {3319--3328},
+  publisher = {PMLR},
+  year = {2017},
+  url = {https://proceedings.mlr.press/v70/sundararajan17a.html},
+}
+
+@article{smilkov2017smoothgrad,
+  author = {Smilkov, Daniel and Thorat, Nikhil and Kim, Been and Vi{\'e}gas, Fernanda and Wattenberg, Martin},
+  title = {{SmoothGrad}: Removing Noise by Adding Noise},
+  journal = {arXiv preprint arXiv:1706.03825},
+  year = {2017},
+  url = {https://arxiv.org/abs/1706.03825},
+}
+
+@inproceedings{zeiler2014visualizing,
+  author = {Zeiler, Matthew D. and Fergus, Rob},
+  title = {Visualizing and Understanding Convolutional Networks},
+  booktitle = {Computer Vision -- ECCV 2014},
+  series = {Lecture Notes in Computer Science},
+  volume = {8689},
+  pages = {818--833},
+  publisher = {Springer},
+  year = {2014},
+  doi = {10.1007/978-3-319-10590-1_53},
+  url = {https://link.springer.com/chapter/10.1007/978-3-319-10590-1_53},
+}
+
+@article{kokhlikyan2020captum,
+  author = {Kokhlikyan, Narine and Miglani, Vivek and Martin, Miguel and Wang, Edward and Alsallakh, Bilal and Reynolds, Jonathan and Melnikov, Alexander and Kliushkina, Natalia and Araya, Carlos and Yan, Siqi and Reblitz-Richardson, Orion},
+  title = {{Captum}: A Unified and Generic Model Interpretability Library for {PyTorch}},
+  journal = {arXiv preprint arXiv:2009.07896},
+  year = {2020},
+  url = {https://arxiv.org/abs/2009.07896},
+}
+
+@inproceedings{petsiuk2018rise,
+  author = {Petsiuk, Vitali and Das, Abir and Saenko, Kate},
+  title = {{RISE}: Randomized Input Sampling for Explanation of Black-Box Models},
+  booktitle = {British Machine Vision Conference},
+  year = {2018},
+  url = {https://bmva-archive.org.uk/bmvc/2018/contents/papers/1064.pdf},
+}
+
+@inproceedings{wu2024faithfulness,
+  author = {Wu, Junyi and Kang, Weitai and Tang, Hao and Hong, Yuan and Yan, Yan},
+  title = {On the Faithfulness of Vision Transformer Explanations},
+  booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition},
+  pages = {10936--10945},
+  year = {2024},
+  url = {https://openaccess.thecvf.com/content/CVPR2024/html/Wu_On_the_Faithfulness_of_Vision_Transformer_Explanations_CVPR_2024_paper.html},
+}
+
+@inproceedings{yeh2019infidelity,
+  author = {Yeh, Chih-Kuan and Hsieh, Cheng-Yu and Suggala, Arun and Inouye, David I. and Ravikumar, Pradeep},
+  title = {On the (In)fidelity and Sensitivity of Explanations},
+  booktitle = {Advances in Neural Information Processing Systems},
+  volume = {32},
+  year = {2019},
+  url = {https://papers.nips.cc/paper_files/paper/2019/hash/a7471fdc77b3435276507cc8f2dc2569-Abstract.html},
+}
+
+@inproceedings{zhang2016excitation,
+  author = {Zhang, Jianming and Lin, Zhe and Brandt, Jonathan and Shen, Xiaohui and Sclaroff, Stan},
+  title = {Top-Down Neural Attention by Excitation Backprop},
+  booktitle = {Computer Vision -- ECCV 2016},
+  series = {Lecture Notes in Computer Science},
+  volume = {9908},
+  pages = {543--559},
+  publisher = {Springer},
+  year = {2016},
+  doi = {10.1007/978-3-319-46493-0_33},
+  url = {https://arxiv.org/abs/1608.00507},
+}
+
+@inproceedings{wang2020scorecam,
+  author = {Wang, Haofan and Wang, Zifan and Du, Mengnan and Yang, Fan and Zhang, Zijian and Ding, Sirui and Mardziel, Piotr and Hu, Xia},
+  title = {{Score-CAM}: Score-Weighted Visual Explanations for Convolutional Neural Networks},
+  booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition Workshops},
+  pages = {24--25},
+  year = {2020},
+  url = {https://openaccess.thecvf.com/content_CVPRW_2020/html/w1/Wang_Score-CAM_Score-Weighted_Visual_Explanations_for_Convolutional_Neural_Networks_CVPRW_2020_paper.html},
+}
+
+@inproceedings{adebayo2018sanity,
+  author = {Adebayo, Julius and Gilmer, Justin and Muelly, Michael and Goodfellow, Ian and Hardt, Moritz and Kim, Been},
+  title = {Sanity Checks for Saliency Maps},
+  booktitle = {Advances in Neural Information Processing Systems},
+  volume = {31},
+  year = {2018},
+  url = {https://proceedings.neurips.cc/paper_files/paper/2018/hash/294a8ed24b1ad22ec2e7efea049b8737-Abstract.html},
+}
+
+@inproceedings{zhang2024activationpatching,
+  author = {Zhang, Fred and Nanda, Neel},
+  title = {Towards Best Practices of Activation Patching in Language Models: Metrics and Methods},
+  booktitle = {International Conference on Learning Representations},
+  year = {2024},
+  url = {https://arxiv.org/abs/2309.16042},
+}
+
+@article{gao2024scaling,
+  author = {Gao, Leo and Dupr{\'e} la Tour, Tom and Tillman, Henk and Goh, Gabriel and Troll, Rajan and Radford, Alec and Sutskever, Ilya and Leike, Jan and Wu, Jeffrey},
+  title = {Scaling and Evaluating Sparse Autoencoders},
+  journal = {arXiv preprint arXiv:2406.04093},
+  year = {2024},
+  url = {https://arxiv.org/abs/2406.04093},
+}
+
+@inproceedings{kim2025residual,
+  author = {Kim, Jinyeong and Kim, Junhyeok and Shim, Yumin and Kim, Joohyeok and Jung, Sunyoung and Hwang, Seong Jae},
+  title = {Interpreting Vision Transformers via Residual Replacement Model},
+  booktitle = {Advances in Neural Information Processing Systems},
+  volume = {38},
+  year = {2025},
+  url = {https://proceedings.neurips.cc/paper_files/paper/2025/hash/50cf815fac839ac68846304ea1613aaa-Abstract-Conference.html},
+}
+
+@inproceedings{mehri2025libragrad,
+  author = {Mehri, Faridoun and Baghshah, Mahdieh Soleymani and Pilehvar, Mohammad Taher},
+  title = {{LibraGrad}: Balancing Gradient Flow for Universally Better Vision Transformer Attributions},
+  booktitle = {Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition},
+  pages = {67--78},
+  year = {2025},
+  url = {https://openaccess.thecvf.com/content/CVPR2025/html/Mehri_LibraGrad_Balancing_Gradient_Flow_for_Universally_Better_Vision_Transformer_Attributions_CVPR_2025_paper.html},
+}
+
+@inproceedings{walker2025metric,
+  author = {Walker, Chase and Jha, Sumit and Ewetz, Rickard},
+  title = {Metric-Driven Attributions for Vision Transformers},
+  booktitle = {International Conference on Learning Representations},
+  year = {2025},
+  url = {https://proceedings.iclr.cc/paper_files/paper/2025/hash/4e21153e79aff242492146d78d09fcdb-Abstract-Conference.html},
+}
+
+@misc{anthropic2025tracing,
+  author = {{Anthropic}},
+  title = {Tracing the Thoughts of a Large Language Model},
+  year = {2025},
+  month = mar,
+  url = {https://www.anthropic.com/research/tracing-thoughts-language-model},
+}
+
+@misc{openai2024concepts,
+  author = {{OpenAI}},
+  title = {Extracting Concepts from {GPT-4}},
+  year = {2024},
+  month = jun,
+  url = {https://openai.com/index/extracting-concepts-from-gpt-4/},
+}

--- a/docs/explainability.md
+++ b/docs/explainability.md
@@ -23,6 +23,13 @@ pip install "vit[explainability] @ git+https://github.com/TidalPaladin/vit.git"
 The extra pins Captum 0.9.0, Matplotlib 3.11.0, and Pillow 12.3.0. Importing `vit.explain` and running
 `vit-explain --help` do not import those optional packages.
 
+## Citing the methods
+
+When publishing results, cite each attribution method and evaluation metric used. Cite Captum as well when using
+`Saliency`, `InputXGradient`, `IntegratedGradients`, `SmoothGrad`, or `PatchOcclusion`. The tables below map every
+public method to its primary source and state where this toolbox implements an adaptation rather than an exact
+reproduction. Copy-ready entries are in [`explainability-references.bib`](explainability-references.bib).
+
 ## Prediction adapter and targets
 
 `output_fn` maps `ViTFeatures` to the downstream output tensor. This boundary preserves the model's real pooling and
@@ -109,18 +116,18 @@ explanation = explainer.attribute(
 `Explanation.token_attributions`, `pixel_attributions`, and `layer_attributions` contain raw method outputs. Signed
 gradient methods preserve negative values. Native positive-relevance methods remain nonnegative by definition.
 
-| Method | Meaning | Main cost and sensitivity |
-|---|---|---|
-| `RawAttention(query=...)` | One layer's attention from selected queries to visual keys | One trace; target-independent; choose a head or average heads |
-| `AttentionRollout(query=...)` | Residual-aware attention flow composed across layers | One trace; target-independent; query choice changes the result |
-| `GradientAttentionRollout(query=...)` | Positive gradient-times-attention relevance composed across layers | One forward and one backward |
-| `LeGrad()` | Positive attention gradients from intermediate post-block predictions, averaged over heads, queries, and layers | One trace plus one gradient call per selected layer |
-| `LayerGradCAM(layer=...)` | Channel-weighted post-block visual-token activations | One forward and one backward; layer choice matters |
-| `Saliency()` | Input gradient | One forward and one backward; signed unless `absolute=True` |
-| `InputXGradient()` | Input multiplied by its gradient | One forward and one backward; signed |
-| `IntegratedGradients()` | Path integral from a baseline to the input | `n_steps` model evaluations; baseline-sensitive; signed and approximately complete |
-| `SmoothGrad()` | Average saliency under input noise | `samples` gradient evaluations; noise-scale-sensitive and reproducible through `seed` |
-| `PatchOcclusion()` | Score change after replacing patch-sized windows | Many model evaluations; baseline-sensitive; supports models without gradients |
+| Method | Meaning | Main cost and sensitivity | Primary reference |
+|---|---|---|---|
+| `RawAttention(query=...)` | One layer's attention from selected queries to visual keys | One trace; target-independent; choose a head or average heads | [Vaswani et al. (2017)](https://arxiv.org/abs/1706.03762); interpretation caveats in [Abnar and Zuidema (2020)](https://aclanthology.org/2020.acl-main.385/) |
+| `AttentionRollout(query=...)` | Residual-aware attention flow composed across layers | One trace; target-independent; query choice changes the result | [Abnar and Zuidema (2020)](https://aclanthology.org/2020.acl-main.385/) |
+| `GradientAttentionRollout(query=...)` | Positive gradient-times-attention relevance composed across layers | One forward and one backward | Implementation-specific method inspired by [Chefer et al. (2021)](https://openaccess.thecvf.com/content/CVPR2021/html/Chefer_Transformer_Interpretability_Beyond_Attention_Visualization_CVPR_2021_paper.html) |
+| `LeGrad()` | Positive attention gradients from intermediate post-block predictions, averaged over heads, queries, and layers | One trace plus one gradient call per selected layer | [Bousselham et al. (2025)](https://openaccess.thecvf.com/content/ICCV2025/html/Bousselham_LeGrad_An_Explainability_Method_for_Vision_Transformers_via_Feature_Formation_ICCV_2025_paper.html) |
+| `LayerGradCAM(layer=...)` | Channel-weighted post-block visual-token activations | One forward and one backward; layer choice matters | ViT token-grid adaptation of [Selvaraju et al. (2017)](https://openaccess.thecvf.com/content_iccv_2017/html/Selvaraju_Grad-CAM_Visual_Explanations_ICCV_2017_paper.html) |
+| `Saliency()` | Input gradient | One forward and one backward; signed unless `absolute=True` | [Simonyan et al. (2014)](https://arxiv.org/abs/1312.6034) |
+| `InputXGradient()` | Input multiplied by its gradient | One forward and one backward; signed | Baseline in [Shrikumar et al. (2017)](https://proceedings.mlr.press/v70/shrikumar17a.html); formal analysis in [Ancona et al. (2018)](https://arxiv.org/abs/1711.06104) |
+| `IntegratedGradients()` | Path integral from a baseline to the input | `n_steps` model evaluations; baseline-sensitive; signed and approximately complete | [Sundararajan et al. (2017)](https://proceedings.mlr.press/v70/sundararajan17a.html) |
+| `SmoothGrad()` | Average saliency under input noise | `samples` gradient evaluations; noise-scale-sensitive and reproducible through `seed` | [Smilkov et al. (2017)](https://arxiv.org/abs/1706.03825) |
+| `PatchOcclusion()` | Score change after replacing patch-sized windows | Many model evaluations; baseline-sensitive; supports models without gradients | Sliding-occlusion method from [Zeiler and Fergus (2014)](https://link.springer.com/chapter/10.1007/978-3-319-10590-1_53) |
 
 LeGrad is the default recommendation for class-specific ViT inspection because it uses feature formation across
 multiple layers. Integrated Gradients and patch occlusion are useful checks with different assumptions.
@@ -129,16 +136,16 @@ Raw attention is not causal evidence. An attention matrix records routing weight
 does not show that changing those routes changes the selected prediction. Use interventions or deletion metrics for
 that question. Attention-method artifact metadata records the explicit query selector used to produce each map.
 
-Method background:
+`GradientAttentionRollout` uses positive gradient times attention, residual identity, row normalization, and layer
+composition. It does not implement the Deep Taylor Decomposition relevance rule in Chefer et al. `LayerGradCAM`
+applies Grad-CAM's channel-weighting rule to a block's visual tokens rather than to convolutional feature maps. The
+five generic input-attribution methods use [Captum](https://arxiv.org/abs/2009.07896); cite both Captum and the
+original algorithm when reporting them.
 
-- [Attention rollout](https://arxiv.org/abs/2005.00928)
-- [LeGrad, ICCV 2025](https://openaccess.thecvf.com/content/ICCV2025/html/Bousselham_LeGrad_An_Explainability_Method_for_Vision_Transformers_via_Feature_Formation_ICCV_2025_paper.html)
-- [Integrated Gradients](https://proceedings.mlr.press/v70/sundararajan17a.html)
-- [SaCo and ViT explanation faithfulness, CVPR 2024](https://openaccess.thecvf.com/content/CVPR2024/html/Wu_On_the_Faithfulness_of_Vision_Transformer_Explanations_CVPR_2024_paper.html)
-- [Parameter-randomization sanity checks](https://proceedings.neurips.cc/paper_files/paper/2018/hash/294a8ed24b1ad22ec2e7efea049b8737-Abstract.html)
-
-LibraGrad and metric-driven attribution are candidates for later `AttributionMethod` implementations. Both require
-validation beyond the backward and optimization paths in this release.
+[LibraGrad](https://openaccess.thecvf.com/content/CVPR2025/html/Mehri_LibraGrad_Balancing_Gradient_Flow_for_Universally_Better_Vision_Transformer_Attributions_CVPR_2025_paper.html)
+and [Metric-Driven Attributions](https://proceedings.iclr.cc/paper_files/paper/2025/hash/4e21153e79aff242492146d78d09fcdb-Abstract-Conference.html)
+are candidates for later `AttributionMethod` implementations. Both require validation beyond the backward and
+optimization paths in this release.
 
 ## Traces
 
@@ -185,7 +192,9 @@ Use `mode="reference"` and `reference_inputs=...` for activation patching. Refer
 same token layout, including masks and original image size. The code rejects incompatible references instead of
 broadcasting them. `explainer.sweep(...)` evaluates a list of interventions independently while sharing the clean
 and reference traces; the changed examples run as one expanded batch, so sweep memory scales with the number of
-interventions.
+interventions. Reference replacement adapts the activation-patching practice surveyed by
+[Zhang and Nanda (2024)](https://arxiv.org/abs/2309.16042) from language models to ViT residual, head, attention, and
+MLP sites.
 
 ## Dataset top activations
 
@@ -227,11 +236,20 @@ report = explainer.evaluate(
 )
 ```
 
-Available metrics are deletion/insertion curves, SaCo, infidelity, sensitivity, completeness residual, localization
-(pointing game and positive relevance mass), and parameter-randomization similarity. Baseline-dependent metrics
-accept an explicit baseline. Metrics exclude masked and padded patches through `TokenLayout.visual_validity`; valid
-patches must have finite attribution values. Evaluation rejects inputs or masks whose token layout differs from the
-explanation. Report baseline choices with results.
+| Metric | Toolbox result | Primary reference |
+|---|---|---|
+| `DeletionInsertion` | Patch-ranked deletion and insertion curves plus area under each curve | Patch-grid adaptation of [Petsiuk et al. (2018)](https://bmva-archive.org.uk/bmvc/2018/contents/papers/1064.pdf) |
+| `SaCo` | Signed pairwise concordance between group relevance and ablation-induced score change | [Wu et al. (2024)](https://openaccess.thecvf.com/content/CVPR2024/html/Wu_On_the_Faithfulness_of_Vision_Transformer_Explanations_CVPR_2024_paper.html) |
+| `Infidelity` | Expected squared mismatch between attribution response and output response | [Yeh et al. (2019)](https://papers.nips.cc/paper_files/paper/2019/hash/a7471fdc77b3435276507cc8f2dc2569-Abstract.html) |
+| `Sensitivity` | Sampled maximum attribution change under bounded Gaussian perturbations | Sampled variant of max-sensitivity from [Yeh et al. (2019)](https://papers.nips.cc/paper_files/paper/2019/hash/a7471fdc77b3435276507cc8f2dc2569-Abstract.html) |
+| `Completeness` | Absolute residual between attribution sum and baseline-to-input score change | Completeness property used by [Sundararajan et al. (2017)](https://proceedings.mlr.press/v70/sundararajan17a.html) |
+| `Localization` | Pointing-game hit and fraction of positive relevance inside a supplied region | [Zhang et al. (2016)](https://arxiv.org/abs/1608.00507); positive-mass form follows the energy-based pointing game used by [Wang et al. (2020)](https://openaccess.thecvf.com/content_CVPRW_2020/html/w1/Wang_Score-CAM_Score-Weighted_Visual_Explanations_for_Convolutional_Neural_Networks_CVPRW_2020_paper.html) |
+| `ParameterRandomizationSanity` | Centered cosine similarity after deterministic full-model randomization | Single-randomization variant of [Adebayo et al. (2018)](https://proceedings.neurips.cc/paper_files/paper/2018/hash/294a8ed24b1ad22ec2e7efea049b8737-Abstract.html) |
+
+Baseline-dependent metrics accept an explicit baseline. Metrics exclude masked and padded patches through
+`TokenLayout.visual_validity`; valid patches must have finite attribution values. Evaluation rejects inputs or masks
+whose token layout differs from the explanation. Report baseline choices, perturbation settings, and adaptation
+details with results.
 
 ## Artifacts and CLI
 
@@ -290,7 +308,11 @@ device; reconstructed trace tensors return to the trace device.
 
 This namespace is experimental and may change independently of the stable toolbox. Interpretable feature claims
 need top-activation inspection, decoded steering, and downstream score recovery, not reconstruction error alone.
-Relevant background includes [residual-stream SAEs for ViTs](https://proceedings.neurips.cc/paper_files/paper/2025/hash/50cf815fac839ac68846304ea1613aaa-Abstract-Conference.html), [Anthropic circuit tracing](https://www.anthropic.com/research/tracing-thoughts-language-model), and [OpenAI's sparse-feature analysis](https://openai.com/index/extracting-concepts-from-gpt-4/).
+The Top-K training design follows [Gao et al. (2024)](https://arxiv.org/abs/2406.04093). ViT-specific evidence comes
+from [Kim et al. (2025)](https://proceedings.neurips.cc/paper_files/paper/2025/hash/50cf815fac839ac68846304ea1613aaa-Abstract-Conference.html),
+which applies sparse autoencoders to ViT residual streams. Broader mechanistic context includes
+[Anthropic's circuit-tracing work](https://www.anthropic.com/research/tracing-thoughts-language-model) and
+[OpenAI's sparse-feature analysis](https://openai.com/index/extracting-concepts-from-gpt-4/).
 
 ## Validation and performance measurement
 

--- a/docs/explainability.md
+++ b/docs/explainability.md
@@ -1,0 +1,327 @@
+# ViT explainability
+
+The `vit.explain` package supports this repository's native `ViT` on two-dimensional inputs. It records transformer
+internals on an eager path while the regular fused and compiled path remains unchanged. Explanation calls use
+evaluation mode and restore module training flags, parameter `requires_grad` flags, and existing gradients before
+returning.
+
+Three-dimensional ViTs are outside the stable scope and raise an actionable error. Gradient methods require a
+floating-point model. Perturbation methods can run on a quantized model when its normal forward method accepts the
+perturbed inputs.
+
+## Installation
+
+Core tracing, native attention methods, interventions, evaluation, and artifact inspection use the base install.
+Captum methods and rendering use the pinned explainability extra:
+
+```bash
+uv sync --group explainability
+# or
+pip install "vit[explainability] @ git+https://github.com/TidalPaladin/vit.git"
+```
+
+The extra pins Captum 0.9.0, Matplotlib 3.11.0, and Pillow 12.3.0. Importing `vit.explain` and running
+`vit-explain --help` do not import those optional packages.
+
+## Prediction adapter and targets
+
+`output_fn` maps `ViTFeatures` to the downstream output tensor. This boundary preserves the model's real pooling and
+head behavior.
+
+```python
+from vit.explain import ViTExplainer
+
+explainer = ViTExplainer(
+    model,
+    output_fn=lambda features: classifier(features.visual_tokens.mean(dim=1)),
+    output_modules=classifier,
+)
+```
+
+List any modules captured by a callable `output_fn` in `output_modules`. Explanation calls put those modules in
+evaluation mode and restore their training flags, parameter gradient flags, and existing gradients with the
+backbone. A module passed directly as `output_fn` is registered automatically.
+
+`ViTExplainer.from_head(model, name)` adapts `AttentivePoolHead`, `TransposedConv2dHead`, and `UpsampleHead`. A plain
+`Head` requires `pool=...`. A pooling `torch.nn.Module` is registered automatically so its state is preserved:
+
+```python
+explainer = ViTExplainer.from_head(
+    model,
+    "linear",
+    pool=lambda features: features.visual_tokens.mean(dim=1),
+)
+```
+
+Targets select one scalar per example. Accepted values are:
+
+- one integer class index shared by the batch;
+- a one-dimensional tensor containing one class index per example;
+- a tuple for one shared dense-output coordinate;
+- a two-dimensional tensor containing one dense coordinate per example;
+- a callable that accepts the output tensor and returns shape `(batch,)`.
+
+Omit `target` only when `output_fn` already returns one scalar per example.
+
+## Reproducing forward inputs
+
+Pass every non-image input with `ForwardArgs`:
+
+```python
+from vit.explain import ForwardArgs
+
+forward_args = ForwardArgs(
+    mask=mask,
+    rope_seed=17,
+    output_norm=True,
+    conditioning=conditioning,
+)
+```
+
+The same values are used by tracing, attribution, intervention, and evaluation forwards. The mask uses the backbone
+convention: `True` retains a visual token. `TokenLayout.visual_indices` maps the shortened model sequence back to the
+full patch grid, and `visual_validity` distinguishes retained patches from masked positions. Ragged batches use `-1`
+indices for padding.
+
+CLS tokens precede register tokens, and both count toward `TokenLayout.prefix_length`. Native attribution methods
+keep only visual-key columns when they return a spatial map. Register tokens can still affect an explanation through
+attention composition and the downstream output.
+
+Patch embedding crops dimensions to an integer number of patches. `TokenLayout.original_size` records the supplied
+image, while `modeled_size` records the crop seen by the model. `interpolate_token_attribution` fills ignored bottom
+and right borders with `NaN` so a rendered map does not imply that the model processed those pixels. An explicit
+output size rescales the attribution directly to that canvas and preserves proportional ignored borders. Passing
+`size=layout.modeled_size` returns only the modeled crop.
+
+## Attribution methods
+
+```python
+from vit.explain import ForwardArgs, LeGrad
+
+explanation = explainer.attribute(
+    inputs,
+    target=3,
+    method=LeGrad(layers=(6, 7, 8, 9, 10, 11)),
+    forward_args=ForwardArgs(mask=mask),
+)
+```
+
+`Explanation.token_attributions`, `pixel_attributions`, and `layer_attributions` contain raw method outputs. Signed
+gradient methods preserve negative values. Native positive-relevance methods remain nonnegative by definition.
+
+| Method | Meaning | Main cost and sensitivity |
+|---|---|---|
+| `RawAttention(query=...)` | One layer's attention from selected queries to visual keys | One trace; target-independent; choose a head or average heads |
+| `AttentionRollout(query=...)` | Residual-aware attention flow composed across layers | One trace; target-independent; query choice changes the result |
+| `GradientAttentionRollout(query=...)` | Positive gradient-times-attention relevance composed across layers | One forward and one backward |
+| `LeGrad()` | Positive attention gradients from intermediate post-block predictions, averaged over heads, queries, and layers | One trace plus one gradient call per selected layer |
+| `LayerGradCAM(layer=...)` | Channel-weighted post-block visual-token activations | One forward and one backward; layer choice matters |
+| `Saliency()` | Input gradient | One forward and one backward; signed unless `absolute=True` |
+| `InputXGradient()` | Input multiplied by its gradient | One forward and one backward; signed |
+| `IntegratedGradients()` | Path integral from a baseline to the input | `n_steps` model evaluations; baseline-sensitive; signed and approximately complete |
+| `SmoothGrad()` | Average saliency under input noise | `samples` gradient evaluations; noise-scale-sensitive and reproducible through `seed` |
+| `PatchOcclusion()` | Score change after replacing patch-sized windows | Many model evaluations; baseline-sensitive; supports models without gradients |
+
+LeGrad is the default recommendation for class-specific ViT inspection because it uses feature formation across
+multiple layers. Integrated Gradients and patch occlusion are useful checks with different assumptions.
+
+Raw attention is not causal evidence. An attention matrix records routing weights inside one forward computation; it
+does not show that changing those routes changes the selected prediction. Use interventions or deletion metrics for
+that question. Attention-method artifact metadata records the explicit query selector used to produce each map.
+
+Method background:
+
+- [Attention rollout](https://arxiv.org/abs/2005.00928)
+- [LeGrad, ICCV 2025](https://openaccess.thecvf.com/content/ICCV2025/html/Bousselham_LeGrad_An_Explainability_Method_for_Vision_Transformers_via_Feature_Formation_ICCV_2025_paper.html)
+- [Integrated Gradients](https://proceedings.mlr.press/v70/sundararajan17a.html)
+- [SaCo and ViT explanation faithfulness, CVPR 2024](https://openaccess.thecvf.com/content/CVPR2024/html/Wu_On_the_Faithfulness_of_Vision_Transformer_Explanations_CVPR_2024_paper.html)
+- [Parameter-randomization sanity checks](https://proceedings.neurips.cc/paper_files/paper/2018/hash/294a8ed24b1ad22ec2e7efea049b8737-Abstract.html)
+
+LibraGrad and metric-driven attribution are candidates for later `AttributionMethod` implementations. Both require
+validation beyond the backward and optimization paths in this release.
+
+## Traces
+
+```python
+from vit.explain import TraceConfig
+
+trace = explainer.trace(
+    inputs,
+    config=TraceConfig(layers=(0, 5, 11), retain_gradients=True),
+    forward_args=forward_args,
+)
+```
+
+Each `LayerTrace` can contain the residual stream before the block, graph-connected attention probabilities,
+per-head value outputs, the projected attention output, the post-attention residual, the MLP output, and the final
+block residual. The eager path computes the block output from the captured attention probabilities. Gradients with
+respect to those probabilities therefore belong to the output that the caller scores.
+
+Traces retain their autograd graph. Release them after use instead of accumulating traces in a long-running process.
+
+## Causal interventions
+
+Supported sites are `residual_pre`, `head_output`, `post_attention`, `mlp_output`, and `residual_post`. Select layers,
+tokens, channels, and attention heads. Replacement modes are zero, constant, user-supplied mean, and reference
+activation.
+
+```python
+from vit.explain import Intervention
+
+effect = explainer.intervene(
+    inputs,
+    target=3,
+    interventions=[
+        Intervention(site="head_output", layer=8, heads=[2, 5], mode="zero"),
+    ],
+    forward_args=forward_args,
+)
+
+print(effect.absolute_change)
+print(effect.relative_change)
+```
+
+Use `mode="reference"` and `reference_inputs=...` for activation patching. Reference and clean traces must have the
+same token layout, including masks and original image size. The code rejects incompatible references instead of
+broadcasting them. `explainer.sweep(...)` evaluates a list of interventions independently while sharing the clean
+and reference traces; the changed examples run as one expanded batch, so sweep memory scales with the number of
+interventions.
+
+## Dataset top activations
+
+`scan_activations` streams a data loader and retains only the top records for each channel:
+
+```python
+atlas = explainer.scan_activations(
+    dataloader,
+    site="residual_pre",
+    layer=7,
+    top_k=20,
+)
+```
+
+Batches can be `(inputs, sample_ids)` pairs or mappings with `inputs` and `sample_ids`. IDs are stored verbatim after
+string conversion. Records contain activation values and patch coordinates. Raw images are not retained. Pass a
+`thumbnail(image, patch_coordinate)` callback when the atlas should retain caller-produced thumbnails. The callback
+is invoked at most once per patch that enters any channel's retained top-k records.
+
+## Evaluation
+
+Visual inspection is insufficient because some saliency methods remain visually plausible after model parameters
+are randomized. Evaluate explanations against the behavior needed for the application.
+
+```python
+from vit.explain import Completeness, DeletionInsertion, Infidelity, SaCo
+
+report = explainer.evaluate(
+    inputs,
+    explanation,
+    target=3,
+    metrics=[
+        DeletionInsertion(steps=20),
+        SaCo(groups=10),
+        Infidelity(samples=32),
+        Completeness(),
+    ],
+    forward_args=forward_args,
+)
+```
+
+Available metrics are deletion/insertion curves, SaCo, infidelity, sensitivity, completeness residual, localization
+(pointing game and positive relevance mass), and parameter-randomization similarity. Baseline-dependent metrics
+accept an explicit baseline. Metrics exclude masked and padded patches through `TokenLayout.visual_validity`; valid
+patches must have finite attribution values. Evaluation rejects inputs or masks whose token layout differs from the
+explanation. Report baseline choices with results.
+
+## Artifacts and CLI
+
+```python
+from vit.explain import load_explanation, save_explanation
+
+save_explanation(explanation, "example.npz")
+loaded = load_explanation("example.npz")
+```
+
+Numeric values are stored in `example.npz`; deterministic metadata is stored in `example.json`. Loading uses
+`numpy.load(..., allow_pickle=False)`. BF16 tensors use exact float32 storage with dtype metadata and are restored to
+BF16 when loaded. Save and load reject array shapes or token mappings that disagree with the recorded layout.
+Tensor-valued method settings, such as an Integrated Gradients baseline, retain shape and dtype provenance without
+retaining the tensor payload. Artifacts exclude source images and model weights.
+
+The CLI reads artifacts. It does not load or execute models:
+
+```bash
+vit-explain --format text inspect example.npz
+vit-explain --format json compare first.npz second.npz
+vit-explain render example.npz heatmap.png --normalization symmetric
+```
+
+Global controls are `--format {text,json}`, `--color {auto,always,never}`, `--no-color`, mutually exclusive `--quiet`
+and `--verbose`, and `--progress {auto,always,never}`. Reports go to stdout. Diagnostics go to stderr. Runtime,
+artifact, optional-dependency, and I/O failures return exit code 2. `render` refuses to replace an output unless
+`--overwrite` is present. `compare` requires identical token layouts, including grid geometry, prefix-token counts,
+visual indices, and validity masks.
+
+## Experimental sparse autoencoders
+
+`vit.explain.experimental.sparse` contains a float32 Top-K sparse autoencoder for streamed residual activations. It
+reports reconstruction MSE, explained variance, L0, dead-feature rate, and optional downstream score recovery. The
+decoder exposes unit-normalized feature directions and decoded feature steering.
+
+```python
+from vit.explain.experimental.sparse import (
+    TopKSparseAutoencoder,
+    scan_sparse_features,
+    stream_vit_activations,
+    train_sparse_autoencoder,
+)
+
+sae = TopKSparseAutoencoder(model.config.hidden_size, 8 * model.config.hidden_size, k=32, device=inputs.device)
+stream = stream_vit_activations(explainer, dataloader, site="residual_post", layer=7)
+losses = train_sparse_autoencoder(sae, stream, steps=1_000)
+atlas = scan_sparse_features(sae, explainer, dataloader, site="residual_post", layer=7, top_k=20)
+```
+
+All batches in one activation stream or feature scan must share the same spatial token layout.
+Activation streams yield only valid visual tokens as a two-dimensional `(tokens, channels)` tensor; ragged padding
+is not used to train the autoencoder. Reconstruction likewise changes only valid visual tokens and leaves prefix and
+padding positions unchanged. Training, feature scans, and reconstruction transfer activations to the autoencoder's
+device; reconstructed trace tensors return to the trace device.
+
+This namespace is experimental and may change independently of the stable toolbox. Interpretable feature claims
+need top-activation inspection, decoded steering, and downstream score recovery, not reconstruction error alone.
+Relevant background includes [residual-stream SAEs for ViTs](https://proceedings.neurips.cc/paper_files/paper/2025/hash/50cf815fac839ac68846304ea1613aaa-Abstract-Conference.html), [Anthropic circuit tracing](https://www.anthropic.com/research/tracing-thoughts-language-model), and [OpenAI's sparse-feature analysis](https://openai.com/index/extracting-concepts-from-gpt-4/).
+
+## Validation and performance measurement
+
+Run the focused explainability suite, then the repository gates:
+
+```bash
+make test-explain
+make check
+make test-ci
+```
+
+Use `examples/benchmark_explainability.py` to measure tracing, LeGrad, Integrated Gradients, patch occlusion, and a
+causal sweep on the current hardware. The script reports latency and CUDA peak memory for a tiny fixture and a
+ViT-B-shaped fixture. Results are descriptive; the repository does not impose hardware-specific thresholds.
+
+The following development measurement used an NVIDIA GeForce RTX 3090 on 2026-07-15, eager execution, batch size 1,
+one measured repeat, and four Integrated Gradients steps. The ViT-B-shaped fixture used 12 layers, width 768, 12
+heads, 224 by 224 inputs, and 16 by 16 patches.
+
+| Fixture | Method | Latency (ms) | CUDA peak (MiB) |
+|---|---|---:|---:|
+| Tiny | Trace | 2.57 | 8.6 |
+| Tiny | LeGrad | 4.87 | 16.9 |
+| Tiny | Integrated Gradients | 10.88 | 17.9 |
+| Tiny | Patch occlusion | 118.84 | 17.0 |
+| Tiny | Four-item causal sweep | 9.44 | 17.2 |
+| ViT-B-shaped | Trace | 11.21 | 517.9 |
+| ViT-B-shaped | LeGrad | 27.63 | 530.0 |
+| ViT-B-shaped | Integrated Gradients | 47.03 | 1025.6 |
+| ViT-B-shaped | Patch occlusion | 1462.89 | 629.8 |
+| ViT-B-shaped | Four-item causal sweep | 89.30 | 695.0 |
+
+Run at least three repeats and use the intended Integrated Gradients step count before drawing performance
+conclusions for a deployment model.

--- a/examples/benchmark_explainability.py
+++ b/examples/benchmark_explainability.py
@@ -1,0 +1,128 @@
+"""Measure explainability latency and CUDA peak memory without fixed thresholds."""
+
+import argparse
+import json
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import torch
+
+from vit import ViT, ViTConfig
+from vit.explain import IntegratedGradients, Intervention, LeGrad, PatchOcclusion, ViTExplainer
+
+
+@dataclass(frozen=True)
+class Result:
+    fixture: str
+    method: str
+    latency_ms: float
+    peak_memory_mib: float | None
+
+
+def make_model(fixture: str, device: torch.device) -> tuple[ViT, torch.Tensor]:
+    if fixture == "tiny":
+        config = ViTConfig(
+            in_channels=3,
+            patch_size=(4, 4),
+            img_size=(32, 32),
+            depth=2,
+            hidden_size=32,
+            ffn_hidden_size=64,
+            num_attention_heads=4,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            pos_enc="rope",
+            dtype=torch.float32,
+        )
+    else:
+        config = ViTConfig(
+            in_channels=3,
+            patch_size=(16, 16),
+            img_size=(224, 224),
+            depth=12,
+            hidden_size=768,
+            ffn_hidden_size=3072,
+            num_attention_heads=12,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            pos_enc="rope",
+            dtype=torch.float32,
+        )
+    model = config.instantiate(device=device).eval()
+    inputs = torch.randn(1, config.in_channels, *config.img_size, device=device, dtype=config.dtype)
+    return model, inputs
+
+
+def synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def measure(name: str, fixture: str, operation: Callable[[], Any], device: torch.device, repeats: int) -> Result:
+    operation()
+    synchronize(device)
+    latencies: list[float] = []
+    peak_memory: float | None = None
+    for _ in range(repeats):
+        if device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(device)
+        start = time.perf_counter()
+        operation()
+        synchronize(device)
+        latencies.append((time.perf_counter() - start) * 1_000)
+        if device.type == "cuda":
+            measured = torch.cuda.max_memory_allocated(device) / (1024**2)
+            peak_memory = measured if peak_memory is None else max(peak_memory, measured)
+    return Result(fixture, name, statistics.median(latencies), peak_memory)
+
+
+def benchmark_fixture(fixture: str, device: torch.device, repeats: int, ig_steps: int) -> list[Result]:
+    model, inputs = make_model(fixture, device)
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean(1)[:, :3])
+    interventions = [
+        Intervention(site="head_output", layer=layer, heads=[0], mode="zero")
+        for layer in range(min(4, model.config.depth))
+    ]
+    operations = {
+        "trace": lambda: explainer.trace(inputs),
+        "legrad": lambda: explainer.attribute(inputs, target=0, method=LeGrad()),
+        "integrated_gradients": lambda: explainer.attribute(
+            inputs,
+            target=0,
+            method=IntegratedGradients(n_steps=ig_steps),
+        ),
+        "patch_occlusion": lambda: explainer.attribute(inputs, target=0, method=PatchOcclusion()),
+        "causal_sweep": lambda: explainer.sweep(inputs, target=0, interventions=interventions),
+    }
+    return [measure(name, fixture, operation, device, repeats) for name, operation in operations.items()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", choices=("tiny", "vit-b", "all"), default="all")
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--ig-steps", type=int, default=8)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args()
+    if args.repeats <= 0 or args.ig_steps <= 0:
+        parser.error("--repeats and --ig-steps must be positive")
+    device = torch.device(args.device)
+    fixtures = ("tiny", "vit-b") if args.fixture == "all" else (args.fixture,)
+    results = [
+        result for fixture in fixtures for result in benchmark_fixture(fixture, device, args.repeats, args.ig_steps)
+    ]
+    if args.format == "json":
+        print(json.dumps([asdict(result) for result in results], sort_keys=True))
+        return
+    print("fixture method latency_ms peak_memory_mib")
+    for result in results:
+        memory = "n/a" if result.peak_memory_mib is None else f"{result.peak_memory_mib:.1f}"
+        print(f"{result.fixture} {result.method} {result.latency_ms:.2f} {memory}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/explain_synthetic.py
+++ b/examples/explain_synthetic.py
@@ -1,0 +1,51 @@
+"""Create, inspect, evaluate, and save a synthetic ViT explanation."""
+
+from pathlib import Path
+
+import torch
+
+from vit import AttentivePoolHeadConfig, ViTConfig
+from vit.explain import DeletionInsertion, LeGrad, ViTExplainer, save_explanation
+
+
+def main() -> None:
+    torch.manual_seed(4)
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(4, 4),
+        img_size=(16, 16),
+        depth=2,
+        hidden_size=16,
+        ffn_hidden_size=32,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="rope",
+        dtype=torch.float32,
+        heads={"prediction": AttentivePoolHeadConfig(out_features=3)},
+    )
+    model = config.instantiate().eval()
+    with torch.no_grad():
+        for layer in range(model.config.depth):
+            block = model.get_block(layer)
+            torch.nn.init.xavier_uniform_(block.self_attention.out_proj.weight)
+            torch.nn.init.xavier_uniform_(block.mlp.fc2.weight)
+
+    inputs = torch.randn(1, 1, 16, 16)
+    explainer = ViTExplainer.from_head(model, "prediction")
+    explanation = explainer.attribute(inputs, target=1, method=LeGrad())
+    report = explainer.evaluate(
+        inputs,
+        explanation,
+        target=1,
+        metrics=[DeletionInsertion(steps=4)],
+    )
+    output = Path("synthetic-explanation.npz")
+    save_explanation(explanation, output, overwrite=True)
+    print(f"saved {output}")
+    print(f"token attribution shape: {tuple(explanation.token_attributions.shape)}")
+    print(f"evaluation metrics: {', '.join(report.metrics)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ force-single-line = false
 combine-as-imports = true
 
 [tool.basedpyright]
-include = ["vit", "tests", "benchmark"]
+include = ["vit", "tests", "benchmark", "examples"]
 exclude = [
   "**/node_modules",
   "**/__pycache__",
@@ -72,17 +72,28 @@ filterwarnings = []
 [project.scripts]
 vit-benchmark = "benchmark.cli:main"
 vit-component-benchmark = "benchmark.component_cli:main"
+vit-explain = "vit.explain.cli:main"
 
 [project.optional-dependencies]
 benchmarking = [
     "matplotlib==3.11.0",
     "tqdm==4.68.4",
 ]
+explainability = [
+    "captum==0.9.0",
+    "matplotlib==3.11.0",
+    "pillow==12.3.0",
+]
 
 [dependency-groups]
 benchmarking = [
     "matplotlib==3.11.0",
     "tqdm==4.68.4",
+]
+explainability = [
+    "captum==0.9.0",
+    "matplotlib==3.11.0",
+    "pillow==12.3.0",
 ]
 
 dev = [
@@ -95,6 +106,7 @@ dev = [
     "coverage==7.15.0",
     "pdbpp==0.12.1",
     {include-group = "benchmarking"},
+    {include-group = "explainability"},
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -14,6 +14,7 @@ from tools.validate_wheel import validate_console_script_targets
 
 PROJECT_ROOT = Path(__file__).parents[1]
 BENCHMARK_DEPENDENCIES = {"matplotlib==3.11.0", "tqdm==4.68.4"}
+EXPLAINABILITY_DEPENDENCIES = {"captum==0.9.0", "matplotlib==3.11.0", "pillow==12.3.0"}
 BENCHMARK_PACKAGES = {"vit", "benchmark"}
 ENTRY_POINTS_PATH = "vit-0.1.1.dist-info/entry_points.txt"
 OPTIONAL_DEPENDENCY_BLOCKER = """
@@ -25,7 +26,7 @@ import sys
 
 class OptionalDependencyBlocker(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     def find_spec(self, fullname, path, target=None):
-        if fullname.partition(".")[0] in {"matplotlib", "tqdm"}:
+        if fullname.partition(".")[0] in {"captum", "matplotlib", "PIL", "tqdm"}:
             return importlib.util.spec_from_loader(fullname, self)
         return None
 
@@ -55,6 +56,18 @@ def test_benchmark_distribution_configuration() -> None:
     assert BENCHMARK_PACKAGES <= wheel_packages
 
 
+def test_explainability_distribution_configuration() -> None:
+    """The explainability extra and artifact CLI must be present in package metadata."""
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    optional_dependencies = set(pyproject["project"]["optional-dependencies"]["explainability"])
+    scripts = pyproject["project"]["scripts"]
+
+    assert optional_dependencies == EXPLAINABILITY_DEPENDENCIES
+    assert scripts["vit-explain"] == "vit.explain.cli:main"
+
+
 def test_readme_git_install_commands_are_single_requirements() -> None:
     """Each direct-reference requirement must be one shell argument to pip."""
     readme = (PROJECT_ROOT / "README.md").read_text()
@@ -68,7 +81,7 @@ def test_readme_git_install_commands_are_single_requirements() -> None:
         assert " @ git+https://github.com/TidalPaladin/vit.git" in arguments[2]
 
 
-@pytest.mark.parametrize("entrypoint", ["benchmark.cli", "benchmark.component_cli"])
+@pytest.mark.parametrize("entrypoint", ["benchmark.cli", "benchmark.component_cli", "vit.explain.cli"])
 def test_benchmark_entrypoint_help_without_optional_dependencies(entrypoint: str) -> None:
     """Always-installed benchmark commands must provide help without the benchmarking extra."""
     result = subprocess.run(

--- a/tests/test_explain_artifacts_cli.py
+++ b/tests/test_explain_artifacts_cli.py
@@ -1,0 +1,310 @@
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from vit import ViT, ViTConfig
+from vit.explain import Explanation, ForwardArgs, ViTExplainer, load_explanation, save_explanation
+from vit.explain.cli import main
+
+
+def make_tiny_config() -> ViTConfig:
+    return ViTConfig(
+        in_channels=3,
+        patch_size=(4, 4),
+        img_size=(9, 10),
+        depth=1,
+        hidden_size=16,
+        ffn_hidden_size=32,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="rope",
+        dtype=torch.float32,
+    )
+
+
+def output_fn(features):
+    return features.visual_tokens.mean(1)[:, :3]
+
+
+def make_explanation() -> Explanation:
+    model = ViT(make_tiny_config()).eval()
+    inputs = torch.randn(1, 3, 9, 10)
+    trace = ViTExplainer(model, output_fn).trace(inputs, forward_args=ForwardArgs(rope_seed=2))
+    return Explanation(
+        method="fixed",
+        token_attributions=torch.arange(4, dtype=torch.float32).view(1, 4),
+        pixel_attributions=None,
+        target_scores=torch.tensor([1.25]),
+        layout=trace.layout,
+        layer_attributions=(torch.ones(1, 4),),
+        configuration={"signed": True, "layers": [0]},
+    )
+
+
+def test_artifact_round_trip_is_non_pickle_and_deterministic(tmp_path: Path) -> None:
+    path = tmp_path / "explanation.npz"
+    explanation = make_explanation()
+
+    save_explanation(explanation, path)
+    first_metadata = path.with_suffix(".json").read_bytes()
+    loaded = load_explanation(path)
+    with np.load(path, allow_pickle=False) as arrays:
+        assert arrays.files
+
+    assert loaded.method == explanation.method
+    assert torch.equal(loaded.token_attributions, explanation.token_attributions)
+    assert loaded.configuration == explanation.configuration
+    save_explanation(explanation, path, overwrite=True)
+    assert path.with_suffix(".json").read_bytes() == first_metadata
+
+
+def test_artifact_round_trip_preserves_bfloat16_tensors(tmp_path: Path) -> None:
+    path = tmp_path / "bfloat16.npz"
+    explanation = make_explanation()
+    pixel_attributions = torch.randn(1, 3, 9, 10, dtype=torch.bfloat16)
+    bfloat16_explanation = replace(
+        explanation,
+        token_attributions=explanation.token_attributions.to(torch.bfloat16),
+        pixel_attributions=pixel_attributions,
+        target_scores=explanation.target_scores.to(torch.bfloat16),
+        layer_attributions=tuple(value.to(torch.bfloat16) for value in explanation.layer_attributions),
+    )
+
+    save_explanation(bfloat16_explanation, path)
+    loaded = load_explanation(path)
+
+    assert loaded.token_attributions.dtype == torch.bfloat16
+    assert loaded.pixel_attributions is not None
+    assert loaded.pixel_attributions.dtype == torch.bfloat16
+    assert loaded.target_scores.dtype == torch.bfloat16
+    assert loaded.layer_attributions[0].dtype == torch.bfloat16
+    assert torch.equal(loaded.token_attributions, bfloat16_explanation.token_attributions)
+    assert torch.equal(loaded.pixel_attributions, pixel_attributions)
+
+
+def test_artifact_refuses_overwrite(tmp_path: Path) -> None:
+    path = tmp_path / "explanation.npz"
+    save_explanation(make_explanation(), path)
+    with pytest.raises(FileExistsError, match="overwrite"):
+        save_explanation(make_explanation(), path)
+
+
+def test_cli_inspect_text_and_json_use_stdout(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "explanation.npz"
+    save_explanation(make_explanation(), path)
+
+    assert main(["--format", "json", "inspect", str(path)]) == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["method"] == "fixed"
+    assert captured.err == ""
+
+
+def test_cli_runtime_failure_uses_stderr_and_exit_two(tmp_path: Path, capsys) -> None:
+    assert main(["inspect", str(tmp_path / "missing.npz")]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "vit-explain failed" in captured.err
+
+
+def test_cli_compare_json(tmp_path: Path, capsys) -> None:
+    first = tmp_path / "first.npz"
+    second = tmp_path / "second.npz"
+    save_explanation(make_explanation(), first)
+    save_explanation(make_explanation(), second)
+
+    assert main(["--format", "json", "compare", str(first), str(second)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cosine_similarity"] == pytest.approx(1.0)
+
+
+def test_cli_compare_rejects_equal_shapes_with_incompatible_layouts(tmp_path: Path, capsys) -> None:
+    first_explanation = make_explanation()
+    second_explanation = replace(
+        first_explanation,
+        layout=replace(first_explanation.layout, grid_size=(1, 4), patch_size=(8, 2)),
+    )
+    first = tmp_path / "first.npz"
+    second = tmp_path / "second.npz"
+    save_explanation(first_explanation, first)
+    save_explanation(second_explanation, second)
+
+    assert main(["compare", str(first), str(second)]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "different token layouts" in captured.err
+
+
+def test_cli_help_does_not_import_optional_dependencies() -> None:
+    blocker = """
+import importlib.abc, importlib.util, sys
+class Blocker(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.partition('.')[0] in {'captum', 'matplotlib', 'PIL'}:
+            return importlib.util.spec_from_loader(fullname, self)
+    def create_module(self, spec): return None
+    def exec_module(self, module): raise ModuleNotFoundError(module.__name__)
+sys.meta_path.insert(0, Blocker())
+from vit.explain.cli import main
+raise SystemExit(main(['--help']))
+"""
+    result = subprocess.run([sys.executable, "-c", blocker], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_render_writes_image_and_enforces_overwrite(tmp_path: Path, capsys) -> None:
+    artifact = tmp_path / "explanation.npz"
+    output = tmp_path / "render.png"
+    save_explanation(make_explanation(), artifact)
+
+    assert main(["render", str(artifact), str(output), "--normalization", "symmetric"]) == 0
+    assert output.is_file()
+    assert "output" in capsys.readouterr().out
+    assert main(["render", str(artifact), str(output)]) == 2
+    assert "overwrite" in capsys.readouterr().err
+    assert main(["--quiet", "render", str(artifact), str(output), "--overwrite"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_render_supports_bfloat16_artifact(tmp_path: Path, capsys) -> None:
+    artifact = tmp_path / "bfloat16.npz"
+    output = tmp_path / "bfloat16.png"
+    explanation = make_explanation()
+    save_explanation(
+        replace(
+            explanation,
+            token_attributions=explanation.token_attributions.to(torch.bfloat16),
+            target_scores=explanation.target_scores.to(torch.bfloat16),
+            layer_attributions=tuple(value.to(torch.bfloat16) for value in explanation.layer_attributions),
+        ),
+        artifact,
+    )
+
+    assert main(["render", str(artifact), str(output)]) == 0
+    assert output.is_file()
+    assert "output" in capsys.readouterr().out
+
+
+def test_cli_verbose_text_compare_and_shape_mismatch(tmp_path: Path, capsys) -> None:
+    first = tmp_path / "first.npz"
+    second = tmp_path / "second.npz"
+    save_explanation(make_explanation(), first)
+    save_explanation(make_explanation(), second)
+
+    assert main(["--verbose", "compare", str(first), str(second)]) == 0
+    captured = capsys.readouterr()
+    assert "cosine_similarity" in captured.out
+    assert "completed compare" in captured.err
+
+
+def test_artifact_validation_rejects_invalid_paths_and_metadata(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match=".npz"):
+        save_explanation(make_explanation(), tmp_path / "bad.bin")
+
+    path = tmp_path / "bad.npz"
+    np.savez(path, token_attributions=np.ones(1))
+    path.with_suffix(".json").write_text('{"artifact_version": 99}')
+    with pytest.raises(ValueError, match="unsupported"):
+        load_explanation(path)
+
+
+def test_artifact_metadata_rejects_non_json_configuration(tmp_path: Path) -> None:
+    explanation = make_explanation()
+    invalid = Explanation(
+        explanation.method,
+        explanation.token_attributions,
+        explanation.pixel_attributions,
+        explanation.target_scores,
+        explanation.layout,
+        configuration={"invalid": object()},
+    )
+    path = tmp_path / "invalid.npz"
+    with pytest.raises(TypeError, match="metadata"):
+        save_explanation(invalid, path)
+    assert not path.exists()
+    assert not path.with_suffix(".json").exists()
+
+
+def test_artifact_save_rejects_attributions_incompatible_with_layout(tmp_path: Path) -> None:
+    explanation = make_explanation()
+    invalid = replace(explanation, token_attributions=explanation.token_attributions[:, :-1])
+    path = tmp_path / "invalid-shape.npz"
+
+    with pytest.raises(ValueError, match="token_attributions"):
+        save_explanation(invalid, path)
+
+    assert not path.exists()
+    assert not path.with_suffix(".json").exists()
+
+
+def test_cli_rejects_malformed_artifact_shapes(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "malformed.npz"
+    save_explanation(make_explanation(), path)
+    with np.load(path, allow_pickle=False) as stored:
+        arrays = {name: stored[name].copy() for name in stored.files}
+    arrays["token_attributions"] = arrays["token_attributions"][:, :-1]
+    np.savez_compressed(path, **arrays)
+
+    assert main(["inspect", str(path)]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "malformed artifact" in captured.err
+
+
+def test_cli_rejects_corrupt_npz_archive(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "corrupt.npz"
+    save_explanation(make_explanation(), path)
+    path.write_bytes(b"PK\x03\x04not-a-valid-archive")
+
+    assert main(["inspect", str(path)]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "vit-explain failed" in captured.err
+
+
+def test_failed_artifact_overwrite_preserves_existing_pair(tmp_path: Path) -> None:
+    path = tmp_path / "explanation.npz"
+    explanation = make_explanation()
+    save_explanation(explanation, path)
+    original_arrays = path.read_bytes()
+    original_metadata = path.with_suffix(".json").read_bytes()
+    invalid = Explanation(
+        explanation.method,
+        explanation.token_attributions + 1,
+        explanation.pixel_attributions,
+        explanation.target_scores,
+        explanation.layout,
+        configuration={"invalid": object()},
+    )
+
+    with pytest.raises(TypeError, match="metadata"):
+        save_explanation(invalid, path, overwrite=True)
+
+    assert path.read_bytes() == original_arrays
+    assert path.with_suffix(".json").read_bytes() == original_metadata
+
+
+def test_cli_applies_color_and_progress_policies(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "explanation.npz"
+    save_explanation(make_explanation(), path)
+
+    assert main(["--color", "always", "--progress", "always", "inspect", str(path)]) == 0
+    captured = capsys.readouterr()
+    assert "\x1b[" in captured.out
+    assert "vit-explain: inspect" in captured.err
+
+    assert main(["--format", "json", "--color", "always", "--progress", "never", "inspect", str(path)]) == 0
+    captured = capsys.readouterr()
+    json.loads(captured.out)
+    assert "\x1b[" not in captured.out
+    assert captured.err == ""
+
+    assert main(["--no-color", "--color", "always", "inspect", str(path)]) == 0
+    assert "\x1b[" not in capsys.readouterr().out

--- a/tests/test_explain_attribution.py
+++ b/tests/test_explain_attribution.py
@@ -1,0 +1,304 @@
+from dataclasses import replace
+
+import pytest
+import torch
+from torch.testing import assert_close
+
+from vit import AttentivePoolHeadConfig, HeadConfig, TransposedConv2dHeadConfig, ViT, ViTConfig
+from vit.explain import (
+    AttentionRollout,
+    ForwardArgs,
+    GradientAttentionRollout,
+    InputXGradient,
+    IntegratedGradients,
+    LayerGradCAM,
+    LeGrad,
+    PatchOcclusion,
+    RawAttention,
+    Saliency,
+    SmoothGrad,
+    ViTExplainer,
+)
+from vit.explain.methods import compose_rollout
+
+
+def make_model(*, head=None, conditioning_size: int | None = None) -> ViT:
+    heads = {} if head is None else {"prediction": head}
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=2,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        drop_path_rate=0.0,
+        num_cls_tokens=1,
+        num_register_tokens=1,
+        pos_enc="learnable",
+        conditioning_size=conditioning_size,
+        adaln_gate_init=1.0,
+        dtype=torch.float32,
+        heads=heads,
+    )
+    model = ViT(config).eval()
+    with torch.no_grad():
+        for index in range(model.config.depth):
+            block = model.get_block(index)
+            block.self_attention.out_proj.weight.normal_(std=0.1)
+            block.mlp.fc2.weight.normal_(std=0.1)
+    return model
+
+
+def output_fn(features):
+    return features.visual_tokens.mean(1)[:, :3]
+
+
+def test_rollout_formula_adds_identity_normalizes_and_composes() -> None:
+    layer_0 = torch.tensor([[[[0.75, 0.25], [0.5, 0.5]]]])
+    layer_1 = torch.tensor([[[[0.25, 0.75], [1.0, 0.0]]]])
+
+    rollout = compose_rollout((layer_0, layer_1))
+
+    normalized_0 = (layer_0[:, 0] + torch.eye(2)) / 2
+    normalized_1 = (layer_1[:, 0] + torch.eye(2)) / 2
+    assert_close(rollout, normalized_1 @ normalized_0)
+
+
+def test_attention_methods_require_explicit_query_selection() -> None:
+    model = make_model()
+    inputs = torch.randn(1, 1, 4, 4)
+    explainer = ViTExplainer(model, output_fn)
+
+    for method in (RawAttention(), AttentionRollout()):
+        with pytest.raises(ValueError, match="query"):
+            explainer.attribute(inputs, method=method)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        RawAttention(query=0),
+        AttentionRollout(query=0),
+        GradientAttentionRollout(query=0),
+        LeGrad(),
+        LayerGradCAM(layer=0),
+    ],
+)
+def test_native_methods_return_raw_full_grid_attributions(method) -> None:
+    torch.manual_seed(5)
+    model = make_model()
+    inputs = torch.randn(2, 1, 4, 4)
+
+    explanation = ViTExplainer(model, output_fn).attribute(inputs, target=1, method=method)
+
+    assert explanation.token_attributions.shape == (2, 4)
+    assert torch.isfinite(explanation.token_attributions).all()
+    assert explanation.pixel_attributions is None
+    assert explanation.target_scores.shape == (2,)
+    assert explanation.layout.grid_size == (2, 2)
+
+
+def test_integrated_gradients_satisfies_completeness_for_linearized_tiny_model() -> None:
+    model = make_model()
+    model.blocks = torch.nn.ModuleList()
+    model._config = replace(model.config, depth=0)
+    inputs = torch.randn(2, 1, 4, 4)
+    baseline = torch.zeros_like(inputs)
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.sum((1, 2)))
+
+    explanation = explainer.attribute(
+        inputs,
+        method=IntegratedGradients(baseline=baseline, n_steps=16),
+    )
+    input_scores = explainer.output_fn(model(inputs))
+    baseline_scores = explainer.output_fn(model(baseline))
+
+    assert explanation.pixel_attributions is not None
+    assert_close(
+        explanation.pixel_attributions.flatten(1).sum(1),
+        input_scores - baseline_scores,
+        atol=1e-4,
+        rtol=1e-4,
+    )
+    assert explanation.configuration["baseline"] == {
+        "kind": "tensor",
+        "shape": list(baseline.shape),
+        "dtype": str(baseline.dtype),
+    }
+
+
+def test_from_head_requires_explicit_pooling_for_plain_head() -> None:
+    model = make_model(head=HeadConfig(out_features=3))
+    with pytest.raises(ValueError, match="pool"):
+        ViTExplainer.from_head(model, "prediction")
+
+    explainer = ViTExplainer.from_head(model, "prediction", pool=lambda features: features.visual_tokens.mean(1))
+    assert explainer.output_fn(model(torch.randn(1, 1, 4, 4))).shape == (1, 3)
+
+
+def test_from_head_preserves_stateful_pool_module() -> None:
+    class StatefulPool(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.norm = torch.nn.BatchNorm1d(8)
+            self.training_states: list[bool] = []
+
+        def forward(self, features) -> torch.Tensor:
+            self.training_states.append(self.training)
+            return self.norm(features.visual_tokens.mean(1))
+
+    model = make_model(head=HeadConfig(out_features=3))
+    pool = StatefulPool().train()
+    assert pool.norm.running_mean is not None
+    running_mean = pool.norm.running_mean.clone()
+    explainer = ViTExplainer.from_head(model, "prediction", pool=pool)
+
+    explainer.attribute(torch.randn(2, 1, 4, 4), target=0, method=InputXGradient())
+
+    assert pool.training_states
+    assert not any(pool.training_states)
+    assert pool.training
+    assert_close(pool.norm.running_mean, running_mean)
+
+
+def test_from_head_adapts_attentive_pooling() -> None:
+    model = make_model(head=AttentivePoolHeadConfig(out_features=3))
+    explainer = ViTExplainer.from_head(model, "prediction")
+    assert explainer.output_fn(model(torch.randn(1, 1, 4, 4))).shape == (1, 3)
+
+
+def test_from_head_adapts_dense_2d_head() -> None:
+    model = make_model(head=TransposedConv2dHeadConfig(out_features=3, kernel_size=2, stride=2, padding=0))
+    explainer = ViTExplainer.from_head(model, "prediction")
+    assert explainer.output_fn(model(torch.randn(1, 1, 4, 4))).shape == (1, 3, 4, 4)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [Saliency(), InputXGradient(), SmoothGrad(samples=2), PatchOcclusion()],
+)
+def test_captum_gradient_and_perturbation_methods(method) -> None:
+    model = make_model()
+    inputs = torch.randn(1, 1, 4, 4)
+
+    explanation = ViTExplainer(model, output_fn).attribute(inputs, target=0, method=method)
+
+    assert explanation.pixel_attributions is not None
+    assert explanation.pixel_attributions.shape == inputs.shape
+    assert explanation.token_attributions.shape == (1, 4)
+
+
+@pytest.mark.parametrize("method", [IntegratedGradients(n_steps=4), SmoothGrad(samples=3)])
+def test_captum_methods_expand_mask_with_internal_batches(method) -> None:
+    model = make_model()
+    inputs = torch.randn(2, 1, 4, 4)
+    mask = torch.tensor([[True, True, False, True], [False, True, True, True]])
+
+    explanation = ViTExplainer(model, output_fn).attribute(
+        inputs,
+        target=0,
+        method=method,
+        forward_args=ForwardArgs(mask=mask),
+    )
+
+    assert explanation.pixel_attributions is not None
+    assert explanation.pixel_attributions.shape == inputs.shape
+    assert torch.isfinite(explanation.pixel_attributions).all()
+
+
+@pytest.mark.parametrize("method", [IntegratedGradients(n_steps=4), SmoothGrad(samples=3)])
+def test_captum_methods_expand_conditioning_with_internal_batches(method) -> None:
+    conditioning_size = 5
+    model = make_model(conditioning_size=conditioning_size)
+    inputs = torch.randn(2, 1, 4, 4)
+    conditioning = torch.randn(2, conditioning_size)
+
+    explanation = ViTExplainer(model, output_fn).attribute(
+        inputs,
+        target=0,
+        method=method,
+        forward_args=ForwardArgs(conditioning=conditioning),
+    )
+
+    assert explanation.pixel_attributions is not None
+    assert explanation.pixel_attributions.shape == inputs.shape
+    assert torch.isfinite(explanation.pixel_attributions).all()
+
+
+def test_legrad_supports_frozen_inference_model() -> None:
+    model = make_model().requires_grad_(False)
+    inputs = torch.randn(1, 1, 4, 4)
+
+    explanation = ViTExplainer(model, output_fn).attribute(inputs, target=0, method=LeGrad())
+
+    assert torch.isfinite(explanation.token_attributions).all()
+    assert not any(parameter.requires_grad for parameter in model.parameters())
+
+
+def test_smoothgrad_is_seeded_and_preserves_caller_rng_state() -> None:
+    torch.manual_seed(17)
+    model = make_model()
+    inputs = torch.randn(1, 1, 4, 4)
+    explainer = ViTExplainer(model, output_fn)
+    method = SmoothGrad(samples=4, stdev=0.2, seed=23)
+    initial_rng_state = torch.random.get_rng_state().clone()
+
+    first = explainer.attribute(inputs, target=0, method=method)
+    after_first = torch.random.get_rng_state().clone()
+    second = explainer.attribute(inputs, target=0, method=method)
+
+    assert first.pixel_attributions is not None
+    assert second.pixel_attributions is not None
+    assert torch.equal(first.pixel_attributions, second.pixel_attributions)
+    assert torch.equal(after_first, initial_rng_state)
+    assert torch.equal(torch.random.get_rng_state(), initial_rng_state)
+    assert first.configuration["seed"] == 23
+
+
+def test_external_output_module_runs_in_eval_mode_and_restores_state() -> None:
+    class RecordingOutput(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.norm = torch.nn.BatchNorm1d(8)
+            self.linear = torch.nn.Linear(8, 3)
+            self.training_states: list[bool] = []
+
+        def forward(self, features) -> torch.Tensor:
+            self.training_states.append(self.training)
+            pooled = features.visual_tokens.mean(1)
+            return self.linear(self.norm(pooled))
+
+    model = make_model()
+    output_module = RecordingOutput().train()
+    inputs = torch.randn(2, 1, 4, 4)
+    assert output_module.norm.running_mean is not None
+    running_mean = output_module.norm.running_mean.clone()
+    explainer = ViTExplainer(model, output_module, output_modules=output_module)
+
+    explainer.attribute(inputs, target=0, method=InputXGradient())
+
+    assert output_module.training_states
+    assert not any(output_module.training_states)
+    assert output_module.training
+    assert_close(output_module.norm.running_mean, running_mean)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        RawAttention(query=[0, 1]),
+        AttentionRollout(query=[0, 1]),
+        GradientAttentionRollout(query=[0, 1]),
+    ],
+)
+def test_attention_method_configuration_serializes_query_selector(method) -> None:
+    explanation = ViTExplainer(make_model(), output_fn).attribute(
+        torch.randn(1, 1, 4, 4),
+        target=0,
+        method=method,
+    )
+
+    assert explanation.configuration["query"] == [0, 1]

--- a/tests/test_explain_evaluation.py
+++ b/tests/test_explain_evaluation.py
@@ -1,0 +1,237 @@
+import pytest
+import torch
+from torch.testing import assert_close
+
+import vit.explain.evaluation as evaluation_module
+from vit import ViT, ViTConfig
+from vit.explain import (
+    Completeness,
+    DeletionInsertion,
+    Explanation,
+    ForwardArgs,
+    Infidelity,
+    InputXGradient,
+    Localization,
+    ParameterRandomizationSanity,
+    SaCo,
+    Sensitivity,
+    ViTExplainer,
+)
+from vit.explain.evaluation import saco_score
+
+
+def make_explainer() -> tuple[ViTExplainer, torch.Tensor]:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=0,
+        hidden_size=4,
+        ffn_hidden_size=8,
+        num_attention_heads=1,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        norm_type="layernorm",
+        dtype=torch.float32,
+    )
+    model = ViT(config).eval()
+    inputs = torch.randn(2, 1, 4, 4)
+    return ViTExplainer(model, lambda features: features.visual_tokens.sum((1, 2))), inputs
+
+
+def test_saco_pairwise_concordance_has_analytical_extremes() -> None:
+    importance = torch.tensor([[3.0, 2.0, 1.0]])
+    assert_close(saco_score(importance, torch.tensor([[3.0, 2.0, 1.0]])), torch.ones(1))
+    assert_close(saco_score(importance, torch.tensor([[1.0, 2.0, 3.0]])), -torch.ones(1))
+
+
+def test_localization_reports_pointing_and_relevance_mass() -> None:
+    explainer, inputs = make_explainer()
+    trace = explainer.trace(inputs)
+    attribution = torch.tensor([[0.0, 0.0, 2.0, 0.0], [0.0, 0.0, 0.0, 3.0]])
+    explanation = Explanation("fixed", attribution, None, torch.zeros(2), trace.layout)
+    region = torch.tensor([[False, False, True, False], [False, False, False, True]])
+
+    result = Localization(region).evaluate(explainer, inputs, explanation, None, trace.forward_args)
+
+    assert_close(result.values, torch.ones(2, 2))
+
+
+def test_completeness_is_exact_for_known_attribution_sum() -> None:
+    explainer, inputs = make_explainer()
+    baseline = torch.zeros_like(inputs)
+    trace = explainer.trace(inputs)
+    input_score = explainer.output_fn(explainer.model(inputs))
+    baseline_score = explainer.output_fn(explainer.model(baseline))
+    difference = input_score - baseline_score
+    attribution = difference[:, None].expand(-1, 4) / 4
+    explanation = Explanation("fixed", attribution, None, input_score, trace.layout)
+
+    result = Completeness(baseline=baseline).evaluate(explainer, inputs, explanation, None, trace.forward_args)
+
+    assert_close(result.values, torch.zeros_like(difference), atol=1e-6, rtol=0)
+
+
+def test_completeness_excludes_pixels_from_masked_patches() -> None:
+    explainer, inputs = make_explainer()
+    inputs = inputs[:1]
+    baseline = torch.zeros_like(inputs)
+    mask = torch.tensor([[True, False, True, False]])
+    forward_args = ForwardArgs(mask=mask)
+    trace = explainer.trace(inputs, forward_args=forward_args)
+    difference = explainer.output_fn(explainer.model(inputs, mask=mask)) - explainer.output_fn(
+        explainer.model(baseline, mask=mask)
+    )
+    pixel_attributions = torch.full_like(inputs, 100.0)
+    pixel_attributions[..., :, :2] = difference.view(1, 1, 1, 1) / 8
+    explanation = Explanation(
+        "fixed",
+        torch.tensor([[0.0, float("nan"), 0.0, float("nan")]]),
+        pixel_attributions,
+        difference,
+        trace.layout,
+    )
+
+    result = Completeness(baseline=baseline).evaluate(explainer, inputs, explanation, None, forward_args)
+
+    assert_close(result.values, torch.zeros_like(difference), atol=1e-6, rtol=0)
+
+
+def test_evaluate_collects_named_metrics() -> None:
+    explainer, inputs = make_explainer()
+    trace = explainer.trace(inputs)
+    explanation = Explanation("fixed", torch.ones(2, 4), None, torch.zeros(2), trace.layout)
+    region = torch.ones(2, 4, dtype=torch.bool)
+
+    report = explainer.evaluate(inputs, explanation, metrics=[Localization(region), SaCo(groups=2)])
+
+    assert set(report.metrics) == {"localization", "saco"}
+
+
+def test_deletion_insertion_returns_both_curves_and_auc() -> None:
+    explainer, inputs = make_explainer()
+    trace = explainer.trace(inputs)
+    explanation = Explanation("fixed", torch.arange(8).view(2, 4).float(), None, torch.zeros(2), trace.layout)
+
+    result = DeletionInsertion(steps=2).evaluate(explainer, inputs, explanation, None, trace.forward_args)
+
+    assert result.values.shape == (2, 2, 3)
+    assert set(result.metadata) == {"deletion_auc", "insertion_auc"}
+
+
+def test_infidelity_supports_pixel_and_token_attributions() -> None:
+    explainer, inputs = make_explainer()
+    trace = explainer.trace(inputs)
+    token_values = torch.ones(2, 4)
+    pixel_values = torch.ones_like(inputs)
+    token_explanation = Explanation("fixed", token_values, None, torch.zeros(2), trace.layout)
+    pixel_explanation = Explanation("fixed", token_values, pixel_values, torch.zeros(2), trace.layout)
+    metric = Infidelity(samples=2, noise_scale=0.001)
+
+    token_result = metric.evaluate(explainer, inputs, token_explanation, None, trace.forward_args)
+    pixel_result = metric.evaluate(explainer, inputs, pixel_explanation, None, trace.forward_args)
+
+    assert torch.isfinite(token_result.values).all()
+    assert torch.isfinite(pixel_result.values).all()
+
+
+def test_masked_metrics_use_only_valid_visual_tokens(mocker) -> None:
+    explainer, inputs = make_explainer()
+    inputs = inputs[:1]
+    mask = torch.tensor([[True, False, True, False]])
+    forward_args = ForwardArgs(mask=mask, output_norm=False)
+    trace = explainer.trace(inputs, forward_args=forward_args)
+    explanation = Explanation(
+        "fixed",
+        torch.tensor([[2.0, float("nan"), 1.0, float("nan")]]),
+        None,
+        torch.zeros(1),
+        trace.layout,
+    )
+    replaced_indices: set[int] = set()
+    original_replace = evaluation_module._replace_patches
+
+    def record_replacement(*args, **kwargs) -> None:
+        patch_indices = args[2]
+        replaced_indices.update(int(index) for index in patch_indices.tolist())
+        original_replace(*args, **kwargs)
+
+    mocker.patch.object(evaluation_module, "_replace_patches", side_effect=record_replacement)
+
+    deletion = DeletionInsertion(steps=2).evaluate(explainer, inputs, explanation, None, forward_args)
+    saco = SaCo(groups=2).evaluate(explainer, inputs, explanation, None, forward_args)
+    infidelity = Infidelity(samples=2).evaluate(explainer, inputs, explanation, None, forward_args)
+    sensitivity = Sensitivity(InputXGradient(), samples=2).evaluate(
+        explainer,
+        inputs,
+        explanation,
+        None,
+        forward_args,
+    )
+
+    assert replaced_indices == {0, 2}
+    for result in (deletion, saco, infidelity, sensitivity):
+        assert torch.isfinite(result.values).all()
+    assert torch.isfinite(saco.metadata["group_importance"]).all()
+
+
+def test_sensitivity_and_parameter_randomization_restore_model() -> None:
+    explainer, inputs = make_explainer()
+    method = InputXGradient()
+    explanation = explainer.attribute(inputs, method=method)
+    state = {name: value.clone() for name, value in explainer.model.state_dict().items()}
+    forward_args = explainer.trace(inputs).forward_args
+
+    sensitivity = Sensitivity(method, samples=2).evaluate(explainer, inputs, explanation, None, forward_args)
+    sanity = ParameterRandomizationSanity(method).evaluate(explainer, inputs, explanation, None, forward_args)
+
+    assert torch.isfinite(sensitivity.values).all()
+    assert torch.isfinite(sanity.values).all()
+    assert (sanity.values < 0.999).all()
+    for name, value in explainer.model.state_dict().items():
+        assert_close(value, state[name])
+
+
+def test_evaluate_rejects_duplicate_metric_names() -> None:
+    explainer, inputs = make_explainer()
+    trace = explainer.trace(inputs)
+    explanation = Explanation("fixed", torch.ones(2, 4), None, torch.zeros(2), trace.layout)
+    region = torch.ones(2, 4, dtype=torch.bool)
+
+    try:
+        explainer.evaluate(inputs, explanation, metrics=[Localization(region), Localization(region)])
+    except ValueError as error:
+        assert "unique" in str(error)
+    else:
+        raise AssertionError("duplicate metric names must fail")
+
+
+def test_evaluate_rejects_inputs_with_different_spatial_layout() -> None:
+    explainer, inputs = make_explainer()
+    trace = explainer.trace(inputs)
+    explanation = Explanation("fixed", torch.ones(2, 4), None, torch.zeros(2), trace.layout)
+
+    with pytest.raises(ValueError, match="token layout"):
+        explainer.evaluate(
+            torch.randn(2, 1, 6, 6),
+            explanation,
+            metrics=[DeletionInsertion(steps=1)],
+        )
+
+
+def test_evaluate_rejects_forward_mask_that_differs_from_explanation() -> None:
+    explainer, inputs = make_explainer()
+    inputs = inputs[:1]
+    explanation_mask = torch.tensor([[True, False, True, False]])
+    trace = explainer.trace(inputs, forward_args=ForwardArgs(mask=explanation_mask))
+    explanation = Explanation(
+        "fixed",
+        torch.tensor([[1.0, float("nan"), 2.0, float("nan")]]),
+        None,
+        torch.zeros(1),
+        trace.layout,
+    )
+
+    with pytest.raises(ValueError, match="token layout"):
+        explainer.evaluate(inputs, explanation, metrics=[DeletionInsertion(steps=1)])

--- a/tests/test_explain_interventions.py
+++ b/tests/test_explain_interventions.py
@@ -1,0 +1,239 @@
+import pytest
+import torch
+from torch.testing import assert_close
+
+from vit import ViT, ViTConfig
+from vit.explain import ForwardArgs, Intervention, ViTExplainer, interventions as intervention_module
+
+
+def make_model(image_size=(4, 4)) -> ViT:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=image_size,
+        depth=2,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        drop_path_rate=0.0,
+        pos_enc="learnable",
+        dtype=torch.float32,
+    )
+    model = ViT(config).eval()
+    with torch.no_grad():
+        for index in range(model.config.depth):
+            block = model.get_block(index)
+            block.self_attention.out_proj.weight.normal_(std=0.2)
+            block.mlp.fc2.weight.normal_(std=0.2)
+    return model
+
+
+def output_fn(features):
+    return features.visual_tokens.mean(1)[:, :2]
+
+
+def test_noop_constant_intervention_is_identity() -> None:
+    model = make_model()
+    inputs = torch.randn(2, 1, 4, 4)
+    explainer = ViTExplainer(model, output_fn)
+    trace = explainer.trace(inputs)
+    value = trace.layers[0].residual_pre.detach()
+
+    result = explainer.intervene(
+        inputs,
+        target=0,
+        interventions=[Intervention(site="residual_pre", layer=0, mode="constant", value=value)],
+    )
+
+    assert_close(result.intervened_scores, result.baseline_scores)
+    assert_close(result.absolute_change, torch.zeros_like(result.absolute_change))
+
+
+def test_head_ablation_changes_only_selected_execution() -> None:
+    torch.manual_seed(3)
+    model = make_model()
+    inputs = torch.randn(2, 1, 4, 4)
+    explainer = ViTExplainer(model, output_fn)
+
+    result = explainer.intervene(
+        inputs,
+        target=1,
+        interventions=[Intervention(site="head_output", layer=0, heads=[0], mode="zero")],
+    )
+
+    assert torch.isfinite(result.absolute_change).all()
+    assert (result.absolute_change.abs() > 0).any()
+
+
+def test_reference_patching_reproduces_reference_score_when_replacing_first_residual() -> None:
+    model = make_model()
+    clean = torch.randn(2, 1, 4, 4)
+    reference = torch.randn(2, 1, 4, 4)
+    explainer = ViTExplainer(model, output_fn)
+
+    result = explainer.intervene(
+        clean,
+        target=0,
+        interventions=[Intervention(site="residual_pre", layer=0, mode="reference")],
+        reference_inputs=reference,
+    )
+    reference_scores = output_fn(model(reference))[:, 0]
+
+    assert_close(result.intervened_scores, reference_scores)
+
+
+def test_reference_patching_rejects_incompatible_layout() -> None:
+    model = make_model()
+    clean = torch.randn(1, 1, 4, 4)
+    reference = torch.randn(1, 1, 5, 4)
+
+    with pytest.raises(ValueError, match="matching token layouts"):
+        ViTExplainer(model, output_fn).intervene(
+            clean,
+            target=0,
+            interventions=[Intervention(site="residual_pre", layer=0, mode="reference")],
+            reference_inputs=reference,
+        )
+
+
+def test_activation_atlas_preserves_ids_and_top_patch_coordinates() -> None:
+    model = make_model()
+    batches = [
+        (torch.zeros(1, 1, 4, 4), ["zero"]),
+        (torch.ones(1, 1, 4, 4), ["one"]),
+    ]
+
+    atlas = ViTExplainer(model, output_fn).scan_activations(
+        batches,
+        site="residual_pre",
+        layer=0,
+        top_k=1,
+    )
+
+    assert atlas.channels
+    record = atlas.channels[0][0]
+    assert record.sample_id in {"zero", "one"}
+    assert len(record.patch_coordinate) == 2
+
+
+def test_activation_atlas_creates_each_patch_thumbnail_at_most_once() -> None:
+    model = make_model()
+    calls: list[tuple[int, int]] = []
+
+    atlas = ViTExplainer(model, output_fn).scan_activations(
+        [(torch.randn(1, 1, 4, 4), ["sample"])],
+        site="residual_pre",
+        layer=0,
+        top_k=4,
+        thumbnail=lambda _image, coordinate: calls.append(coordinate) or coordinate,
+    )
+
+    assert atlas.channels
+    assert calls == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+
+@pytest.mark.parametrize("site", ["residual_pre", "post_attention", "mlp_output", "residual_post"])
+def test_token_channel_interventions_cover_each_residual_site(site) -> None:
+    model = make_model()
+    inputs = torch.randn(1, 1, 4, 4)
+
+    result = ViTExplainer(model, output_fn).intervene(
+        inputs,
+        target=0,
+        interventions=[Intervention(site=site, layer=0, tokens=[0, 1], channels=[0, 1], mode="zero")],
+    )
+
+    assert torch.isfinite(result.intervened_scores).all()
+
+
+def test_user_supplied_mean_intervention() -> None:
+    model = make_model()
+    inputs = torch.randn(1, 1, 4, 4)
+    channel_mean = torch.arange(8, dtype=inputs.dtype)
+
+    result = ViTExplainer(model, output_fn).intervene(
+        inputs,
+        target=0,
+        interventions=[Intervention(site="residual_pre", layer=0, mode="mean", value=channel_mean)],
+    )
+
+    assert torch.isfinite(result.intervened_scores).all()
+
+
+def test_sweep_batches_interventions_and_reuses_baseline(mocker) -> None:
+    model = make_model()
+    inputs = torch.randn(2, 1, 4, 4)
+    mask = torch.tensor([[True, True, False, True], [False, True, True, True]])
+    target = torch.tensor([0, 1])
+    requested = (
+        Intervention(site="residual_pre", layer=0, tokens=[0], mode="zero"),
+        Intervention(site="head_output", layer=0, heads=[0], mode="zero"),
+        Intervention(site="mlp_output", layer=1, channels=[0, 1], mode="zero"),
+    )
+    grad_states: list[bool] = []
+
+    def recording_output(features):
+        grad_states.append(torch.is_grad_enabled())
+        return output_fn(features)
+
+    explainer = ViTExplainer(model, recording_output)
+    expected = tuple(
+        explainer.intervene(
+            inputs,
+            target=target,
+            interventions=[item],
+            forward_args=ForwardArgs(mask=mask),
+        )
+        for item in requested
+    )
+    grad_states.clear()
+    trace_spy = mocker.spy(intervention_module, "trace_vit")
+
+    actual = explainer.sweep(
+        inputs,
+        target=target,
+        interventions=requested,
+        forward_args=ForwardArgs(mask=mask),
+    )
+
+    assert trace_spy.call_count == 2
+    assert trace_spy.call_args_list[0].args[1].shape[0] == inputs.shape[0]
+    assert trace_spy.call_args_list[1].args[1].shape[0] == len(requested) * inputs.shape[0]
+    assert grad_states and not any(grad_states)
+    for expected_result, actual_result in zip(expected, actual, strict=True):
+        assert_close(actual_result.baseline_scores, expected_result.baseline_scores)
+        assert_close(actual_result.intervened_scores, expected_result.intervened_scores)
+
+
+def test_sweep_reuses_one_reference_trace(mocker) -> None:
+    model = make_model()
+    clean = torch.randn(2, 1, 4, 4)
+    reference = torch.randn(2, 1, 4, 4)
+    requested = (
+        Intervention(site="residual_pre", layer=0, mode="reference"),
+        Intervention(site="residual_post", layer=0, mode="reference"),
+    )
+    explainer = ViTExplainer(model, output_fn)
+    expected = tuple(
+        explainer.intervene(
+            clean,
+            target=0,
+            interventions=[item],
+            reference_inputs=reference,
+        )
+        for item in requested
+    )
+    trace_spy = mocker.spy(intervention_module, "trace_vit")
+
+    actual = explainer.sweep(
+        clean,
+        target=0,
+        interventions=requested,
+        reference_inputs=reference,
+    )
+
+    assert trace_spy.call_count == 3
+    for expected_result, actual_result in zip(expected, actual, strict=True):
+        assert_close(actual_result.intervened_scores, expected_result.intervened_scores)

--- a/tests/test_explain_sparse.py
+++ b/tests/test_explain_sparse.py
@@ -1,0 +1,308 @@
+import pytest
+import torch
+from torch.testing import assert_close
+
+from vit import ViT, ViTConfig
+from vit.explain import ForwardArgs, Intervention, ViTExplainer
+from vit.explain.experimental.sparse import (
+    TopKSparseAutoencoder,
+    reconstruct_trace_site,
+    scan_sparse_features,
+    score_recovery,
+    sparse_metrics,
+    stream_vit_activations,
+    train_sparse_autoencoder,
+)
+
+
+def test_topk_sparse_autoencoder_has_exact_sparsity_and_normalized_decoder() -> None:
+    model = TopKSparseAutoencoder(input_features=6, dictionary_features=12, k=3)
+    inputs = torch.randn(5, 6)
+
+    reconstruction, codes = model(inputs)
+    model.normalize_decoder_()
+
+    assert reconstruction.shape == inputs.shape
+    assert (codes != 0).sum(1).eq(3).all()
+    assert_close(model.decoder_directions.norm(dim=1), torch.ones(12))
+
+
+def test_sparse_metrics_account_for_dead_features_and_reconstruction() -> None:
+    inputs = torch.randn(8, 4)
+    reconstruction = inputs.clone()
+    codes = torch.zeros(8, 6)
+    codes[:, :2] = 1
+
+    metrics = sparse_metrics(inputs, reconstruction, codes)
+
+    assert metrics.reconstruction_mse == 0
+    assert metrics.explained_variance == 1
+    assert metrics.l0 == 2
+    assert metrics.dead_feature_rate == 4 / 6
+
+
+def test_decoded_feature_steering_follows_decoder_direction() -> None:
+    model = TopKSparseAutoencoder(input_features=4, dictionary_features=8, k=2)
+    model.normalize_decoder_()
+    activations = torch.zeros(3, 4)
+
+    steered = model.steer(activations, feature=3, coefficient=2.5)
+
+    expected = 2.5 * model.decoder_directions[3]
+    assert_close(steered, expected.expand_as(steered))
+
+
+def test_reconstructed_residual_can_be_injected_for_score_recovery() -> None:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=1,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        dtype=torch.float32,
+    )
+    model = ViT(config).eval()
+    inputs = torch.randn(2, 1, 4, 4)
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean((1, 2)))
+    trace = explainer.trace(inputs)
+    autoencoder = TopKSparseAutoencoder(8, 16, k=4)
+    reconstructed = reconstruct_trace_site(autoencoder, trace, site="residual_post", layer=0)
+
+    result = explainer.intervene(
+        inputs,
+        target=None,
+        interventions=[
+            Intervention(site="residual_post", layer=0, mode="constant", value=reconstructed),
+        ],
+    )
+
+    assert reconstructed.shape == trace.layers[0].residual_post.shape
+    assert torch.isfinite(result.intervened_scores).all()
+
+    head_autoencoder = TopKSparseAutoencoder(8, 16, k=4)
+    reconstructed_heads = reconstruct_trace_site(head_autoencoder, trace, site="head_output", layer=0)
+    assert reconstructed_heads.shape == trace.layers[0].head_outputs.shape
+
+
+@pytest.mark.parametrize("site", ["residual_pre", "head_output"])
+def test_reconstruction_preserves_ragged_padding(site) -> None:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=1,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        dtype=torch.float32,
+    )
+    model = ViT(config).eval()
+    inputs = torch.randn(2, 1, 4, 4)
+    mask = torch.tensor([[True, True, True, False], [False, True, False, False]])
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean((1, 2)))
+    trace = explainer.trace(inputs, forward_args=ForwardArgs(mask=mask))
+    autoencoder = TopKSparseAutoencoder(8, 16, k=4)
+    with torch.no_grad():
+        autoencoder.encoder.weight.zero_()
+        autoencoder.encoder.bias.zero_()
+        autoencoder.decoder_bias.fill_(1.0)
+
+    reconstructed = reconstruct_trace_site(autoencoder, trace, site=site, layer=0)
+    original = trace.layers[0].residual_pre if site == "residual_pre" else trace.layers[0].head_outputs
+    if site == "head_output":
+        original = original.permute(0, 2, 1, 3).flatten(2)
+        reconstructed = reconstructed.permute(0, 2, 1, 3).flatten(2)
+    else:
+        original = original[:, trace.layout.prefix_length :]
+        reconstructed = reconstructed[:, trace.layout.prefix_length :]
+
+    padding = ~trace.layout.sequence_validity
+    assert_close(reconstructed[padding], original[padding])
+
+
+@pytest.mark.cuda
+def test_reconstruction_supports_cpu_autoencoder_with_cuda_trace() -> None:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=1,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        dtype=torch.float32,
+    )
+    model = ViT(config, device=torch.device("cuda")).eval()
+    inputs = torch.randn(1, 1, 4, 4, device="cuda")
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean((1, 2)))
+    trace = explainer.trace(inputs)
+    autoencoder = TopKSparseAutoencoder(8, 16, k=4)
+
+    reconstructed = reconstruct_trace_site(autoencoder, trace, site="residual_post", layer=0)
+
+    assert reconstructed.device.type == "cuda"
+    assert reconstructed.shape == trace.layers[0].residual_post.shape
+
+
+def test_sparse_training_restarts_reusable_stream_and_reduces_loss() -> None:
+    torch.manual_seed(2)
+    autoencoder = TopKSparseAutoencoder(4, 8, k=3)
+    batches = [torch.randn(16, 4)]
+
+    losses = train_sparse_autoencoder(autoencoder, batches, steps=30, learning_rate=2e-2)
+
+    assert len(losses) == 30
+    assert all(torch.isfinite(torch.tensor(losses)))
+    assert losses[-1] < losses[0]
+    assert_close(autoencoder.decoder_directions.norm(dim=1), torch.ones(8))
+
+
+def test_score_recovery_has_expected_endpoints() -> None:
+    original = torch.tensor([3.0])
+    ablated = torch.tensor([1.0])
+    assert_close(score_recovery(original, original, ablated), torch.ones(1))
+    assert_close(score_recovery(original, ablated, ablated), torch.zeros(1))
+
+
+def test_vit_activation_stream_restores_model_before_yield_and_is_restartable() -> None:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=1,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        dtype=torch.float32,
+    )
+    model = ViT(config).train()
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean((1, 2)))
+    dataloader = [(torch.randn(2, 1, 4, 4), ["a", "b"])]
+    stream = stream_vit_activations(explainer, dataloader, site="residual_post", layer=0)
+
+    iterator = iter(stream)
+    next(iterator)
+    assert model.training
+    first = list(stream)
+    second = list(stream)
+    autoencoder = TopKSparseAutoencoder(8, 12, k=3)
+    atlas = scan_sparse_features(autoencoder, explainer, dataloader, site="residual_post", layer=0, top_k=1)
+
+    assert_close(first[0], second[0])
+    assert model.training
+    assert atlas.features
+    assert atlas.features[0][0].sample_id in {"a", "b"}
+
+
+def test_vit_activation_stream_excludes_ragged_padding_tokens() -> None:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=1,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        dtype=torch.float32,
+    )
+    model = ViT(config).eval()
+    inputs = torch.randn(2, 1, 4, 4)
+    mask = torch.tensor([[True, True, True, False], [False, True, False, False]])
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean((1, 2)))
+    arguments = ForwardArgs(mask=mask)
+    trace = explainer.trace(inputs, forward_args=arguments)
+    expected = trace.layers[0].residual_post[:, trace.layout.prefix_length :][trace.layout.sequence_validity]
+
+    streamed = next(
+        iter(
+            stream_vit_activations(
+                explainer,
+                [inputs],
+                site="residual_post",
+                layer=0,
+                forward_args=arguments,
+            )
+        )
+    )
+
+    assert streamed.shape == (int(mask.sum().item()), config.hidden_size)
+    assert_close(streamed, expected)
+
+
+def test_sparse_feature_scan_rejects_incompatible_batch_layouts() -> None:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=1,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        dtype=torch.float32,
+    )
+    model = ViT(config).eval()
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean((1, 2)))
+    autoencoder = TopKSparseAutoencoder(8, 12, k=3)
+    dataloader = [torch.randn(1, 1, 4, 4), torch.randn(1, 1, 6, 4)]
+
+    with pytest.raises(ValueError, match="layout"):
+        scan_sparse_features(autoencoder, explainer, dataloader, site="residual_post", layer=0)
+
+
+@pytest.mark.cuda
+def test_sparse_feature_scan_supports_cpu_autoencoder_with_cuda_model() -> None:
+    config = ViTConfig(
+        in_channels=1,
+        patch_size=(2, 2),
+        img_size=(4, 4),
+        depth=1,
+        hidden_size=8,
+        ffn_hidden_size=16,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        pos_enc="none",
+        dtype=torch.float32,
+    )
+    model = ViT(config, device=torch.device("cuda")).eval()
+    inputs = torch.randn(1, 1, 4, 4, device="cuda")
+    explainer = ViTExplainer(model, lambda features: features.visual_tokens.mean((1, 2)))
+    autoencoder = TopKSparseAutoencoder(8, 12, k=3)
+
+    atlas = scan_sparse_features(autoencoder, explainer, [inputs], site="residual_post", layer=0, top_k=1)
+
+    assert atlas.features
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"input_features": 0, "dictionary_features": 4, "k": 1},
+        {"input_features": 4, "dictionary_features": 0, "k": 1},
+        {"input_features": 4, "dictionary_features": 4, "k": 0},
+        {"input_features": 4, "dictionary_features": 4, "k": 5},
+    ],
+)
+def test_sparse_autoencoder_rejects_invalid_dimensions(arguments) -> None:
+    with pytest.raises(ValueError):
+        TopKSparseAutoencoder(**arguments)

--- a/tests/test_explain_trace.py
+++ b/tests/test_explain_trace.py
@@ -1,0 +1,145 @@
+from dataclasses import replace
+
+import pytest
+import torch
+from torch.testing import assert_close
+
+from vit import ViT, ViTConfig
+from vit.explain import ForwardArgs, TraceConfig, ViTExplainer
+
+
+def make_tiny_config(**overrides) -> ViTConfig:
+    config = ViTConfig(
+        in_channels=3,
+        patch_size=(4, 4),
+        img_size=(9, 10),
+        depth=2,
+        hidden_size=16,
+        ffn_hidden_size=32,
+        num_attention_heads=2,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        drop_path_rate=0.0,
+        num_cls_tokens=1,
+        num_register_tokens=2,
+        pos_enc="rope",
+        dtype=torch.float32,
+    )
+    return replace(config, **overrides)
+
+
+def output_fn(features):
+    return features.visual_tokens.mean(dim=1)[..., :3]
+
+
+def test_prefix_length_counts_cls_and_register_tokens() -> None:
+    model = ViT(make_tiny_config())
+    assert model.prefix_length == 3
+
+
+def test_trace_matches_eval_forward_and_preserves_full_visual_layout() -> None:
+    torch.manual_seed(7)
+    model = ViT(make_tiny_config()).eval()
+    inputs = torch.randn(2, 3, 9, 10)
+    mask = torch.tensor([[True, False, True, False], [False, True, True, False]])
+    forward_args = ForwardArgs(mask=mask, rope_seed=13)
+    explainer = ViTExplainer(model, output_fn)
+
+    expected = model(inputs, mask=mask, rope_seed=13)
+    trace = explainer.trace(inputs, config=TraceConfig(retain_gradients=True), forward_args=forward_args)
+
+    assert_close(trace.features.dense_features, expected.dense_features)
+    assert trace.layout.grid_size == (2, 2)
+    assert trace.layout.modeled_size == (8, 8)
+    assert trace.layout.original_size == (9, 10)
+    assert_close(trace.layout.visual_validity, mask)
+    assert len(trace.layers) == model.config.depth
+    assert trace.layers[0].attention_probabilities.shape == (2, 2, 5, 5)
+    assert trace.layers[0].attention_probabilities.requires_grad
+
+
+def test_trace_restores_model_and_existing_gradients() -> None:
+    model = ViT(make_tiny_config()).train()
+    inputs = torch.randn(1, 3, 9, 10, requires_grad=True)
+    parameter = next(model.parameters())
+    parameter.grad = torch.full_like(parameter, 2.0)
+    original_gradient = parameter.grad.clone()
+    original_requires_grad = {name: value.requires_grad for name, value in model.named_parameters()}
+
+    ViTExplainer(model, output_fn).trace(inputs)
+
+    assert model.training
+    assert {name: value.requires_grad for name, value in model.named_parameters()} == original_requires_grad
+    assert parameter.grad is not None
+    assert_close(parameter.grad, original_gradient)
+    assert inputs.grad is None
+
+
+def test_explainability_rejects_3d_inputs() -> None:
+    config = make_tiny_config(patch_size=(2, 4, 4), img_size=(4, 8, 8))
+    model = ViT(config)
+    inputs = torch.randn(1, 3, 4, 8, 8)
+
+    with pytest.raises(ValueError, match="supports 2D ViT inputs"):
+        ViTExplainer(model, output_fn).trace(inputs)
+
+
+@pytest.mark.parametrize(
+    ("pos_enc", "norm_type", "dtype", "masked", "conditioned"),
+    [
+        ("none", "rmsnorm", torch.float32, False, False),
+        ("fourier", "layernorm", torch.float32, True, False),
+        ("learnable", "rmsnorm", torch.bfloat16, False, True),
+        ("rope", "layernorm", torch.bfloat16, True, True),
+    ],
+)
+def test_trace_forward_parity_across_model_variants(pos_enc, norm_type, dtype, masked, conditioned) -> None:
+    torch.manual_seed(11)
+    config = make_tiny_config(
+        pos_enc=pos_enc,
+        norm_type=norm_type,
+        dtype=dtype,
+        conditioning_size=5 if conditioned else None,
+        adaln_gate_init=1.0 if conditioned else 0.0,
+    )
+    model = ViT(config).eval()
+    inputs = torch.randn(2, 3, 9, 10, dtype=dtype)
+    mask = torch.tensor([[True, False, True, False], [False, True, True, False]]) if masked else None
+    conditioning = torch.randn(2, 5, dtype=dtype) if conditioned else None
+    forward_args = ForwardArgs(mask=mask, rope_seed=19, output_norm=False, conditioning=conditioning)
+
+    expected = model(
+        inputs,
+        mask=mask,
+        rope_seed=19,
+        output_norm=False,
+        conditioning=conditioning,
+    )
+    actual = ViTExplainer(model, output_fn).trace(inputs, forward_args=forward_args).features
+
+    tolerance = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    assert_close(actual.dense_features, expected.dense_features, atol=tolerance, rtol=tolerance)
+
+
+@pytest.mark.cuda
+def test_trace_forward_parity_on_cuda() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    model = ViT(make_tiny_config(dtype=torch.bfloat16), device=torch.device("cuda")).eval()
+    inputs = torch.randn(1, 3, 9, 10, device="cuda", dtype=torch.bfloat16)
+    expected = model(inputs)
+    actual = ViTExplainer(model, output_fn).trace(inputs).features
+    assert_close(actual.dense_features, expected.dense_features, atol=2e-2, rtol=2e-2)
+
+
+def test_ragged_mask_layout_distinguishes_padding_from_visual_tokens() -> None:
+    model = ViT(make_tiny_config()).eval()
+    inputs = torch.randn(2, 3, 9, 10)
+    mask = torch.tensor([[True, True, True, False], [False, True, False, False]])
+
+    expected = model(inputs, mask=mask)
+    trace = ViTExplainer(model, output_fn).trace(inputs, forward_args=ForwardArgs(mask=mask))
+
+    assert_close(trace.features.dense_features, expected.dense_features)
+    assert trace.layout.visual_indices.tolist() == [[0, 1, 2], [1, -1, -1]]
+    assert trace.layout.sequence_validity.tolist() == [[True, True, True], [True, False, False]]

--- a/tests/test_explain_types_visualization.py
+++ b/tests/test_explain_types_visualization.py
@@ -1,0 +1,125 @@
+import pytest
+import torch
+import torch.nn.functional as F
+from test_explain_trace import make_tiny_config, output_fn
+from torch.testing import assert_close
+
+from vit import ViT
+from vit.explain import (
+    Explanation,
+    ForwardArgs,
+    ViTExplainer,
+    interpolate_token_attribution,
+    normalize_attribution,
+)
+from vit.explain.types import TokenLayout, select_targets
+
+
+def test_target_selection_supports_shared_per_example_dense_and_callable_targets() -> None:
+    outputs = torch.arange(24).view(2, 3, 4)
+    class_outputs = torch.arange(6).view(2, 3)
+
+    assert_close(select_targets(class_outputs, 1), torch.tensor([1, 4]))
+    assert_close(select_targets(class_outputs, torch.tensor([0, 2])), torch.tensor([0, 5]))
+    assert_close(select_targets(outputs, (1, 2)), torch.tensor([6, 18]))
+    assert_close(select_targets(outputs, torch.tensor([[0, 1], [2, 3]])), torch.tensor([1, 23]))
+    assert_close(select_targets(class_outputs[:, 0], None), torch.tensor([0, 3]))
+    assert_close(select_targets(class_outputs, lambda values: values[:, 2]), torch.tensor([2, 5]))
+
+
+@pytest.mark.parametrize("target", [None, torch.ones(2, 2, 2, dtype=torch.long), "bad"])
+def test_target_selection_rejects_ambiguous_targets(target) -> None:
+    outputs = torch.ones(2, 3)
+    with pytest.raises((TypeError, ValueError)):
+        select_targets(outputs, target)
+
+
+def test_token_layout_scatter_validates_batch_and_token_dimensions() -> None:
+    model = ViT(make_tiny_config()).eval()
+    trace = ViTExplainer(model, output_fn).trace(torch.randn(1, 3, 9, 10))
+
+    with pytest.raises(ValueError, match="batch"):
+        trace.layout.scatter_visual(torch.ones(2, 4))
+    with pytest.raises(ValueError, match="token"):
+        trace.layout.scatter_visual(torch.ones(1, 3))
+
+
+@pytest.mark.parametrize("mode", ["none", "minmax", "symmetric", "absolute"])
+def test_normalization_modes_preserve_nan_locations(mode) -> None:
+    values = torch.tensor([[[-2.0, float("nan")], [1.0, 2.0]]])
+    result = normalize_attribution(values, mode)
+    assert torch.isnan(result[0, 0, 1])
+    assert torch.isfinite(result[0, 0, 0])
+
+
+def test_minmax_normalization_ignores_nan_locations() -> None:
+    values = torch.tensor([[1.0, 2.0, 3.0, float("nan")]])
+
+    result = normalize_attribution(values, "minmax")
+
+    assert_close(result[:, :3], torch.tensor([[0.0, 0.5, 1.0]]))
+    assert torch.isnan(result[:, 3]).all()
+
+
+def test_interpolation_marks_ignored_borders_and_supports_modeled_size() -> None:
+    model = ViT(make_tiny_config()).eval()
+    trace = ViTExplainer(model, output_fn).trace(torch.randn(1, 3, 9, 10))
+    explanation = Explanation("fixed", torch.ones(1, 4), None, torch.zeros(1), trace.layout)
+
+    original = interpolate_token_attribution(explanation, normalization="minmax")
+    modeled = interpolate_token_attribution(explanation, size=trace.layout.modeled_size)
+
+    assert original.shape == (1, 9, 10)
+    assert torch.isnan(original[:, 8:, :]).all()
+    assert torch.isnan(original[:, :, 8:]).all()
+    assert modeled.shape == (1, 8, 8)
+
+
+def test_interpolation_preserves_masked_patches_without_nan_spread() -> None:
+    model = ViT(make_tiny_config()).eval()
+    inputs = torch.randn(1, 3, 9, 10)
+    mask = torch.tensor([[True, False, True, False]])
+    trace = ViTExplainer(model, output_fn).trace(inputs, forward_args=ForwardArgs(mask=mask))
+    token_attributions = torch.tensor([[1.0, float("nan"), 3.0, float("nan")]])
+    explanation = Explanation("fixed", token_attributions, None, torch.zeros(1), trace.layout)
+
+    rendered = interpolate_token_attribution(
+        explanation,
+        size=trace.layout.modeled_size,
+        normalization="minmax",
+    )
+
+    patch_height, patch_width = trace.layout.patch_size
+    assert torch.isfinite(rendered[:, :, :patch_width]).all()
+    assert torch.isnan(rendered[:, :patch_height, patch_width:]).all()
+    assert torch.isnan(rendered[:, patch_height:, patch_width:]).all()
+
+
+def test_interpolation_resizes_directly_to_arbitrary_requested_size() -> None:
+    layout = TokenLayout(
+        grid_size=(2, 2),
+        patch_size=(4, 4),
+        original_size=(8, 8),
+        modeled_size=(8, 8),
+        num_cls_tokens=0,
+        num_register_tokens=0,
+        visual_indices=torch.arange(4).view(1, 4),
+        visual_validity=torch.ones(1, 4, dtype=torch.bool),
+    )
+    token_attributions = torch.arange(4, dtype=torch.float32).view(1, 4)
+    explanation = Explanation("fixed", token_attributions, None, torch.zeros(1), layout)
+
+    rendered = interpolate_token_attribution(explanation, size=(4, 4))
+    expected = F.interpolate(
+        token_attributions.view(1, 1, 2, 2),
+        size=(4, 4),
+        mode="bilinear",
+        align_corners=False,
+    )[:, 0]
+
+    assert_close(rendered, expected)
+
+
+def test_normalization_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="normalization"):
+        normalize_attribution(torch.ones(1, 2), "unknown")  # type: ignore[arg-type]

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -664,6 +664,32 @@ class TestViT:
         weights = model.forward_attention_weights(x, conditioning=conditioning)
         assert len(weights) == config.depth
 
+    def test_forward_attention_weights_counts_cls_prefix_and_scatters_masked_keys(self):
+        config = ViTConfig(
+            in_channels=1,
+            patch_size=(2, 2),
+            img_size=(4, 4),
+            depth=1,
+            hidden_size=8,
+            ffn_hidden_size=16,
+            num_attention_heads=2,
+            num_cls_tokens=1,
+            num_register_tokens=2,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            pos_enc="rope",
+            dtype=torch.float32,
+        )
+        model = ViT(config).eval()
+        inputs = torch.randn(1, 1, 4, 4)
+        mask = torch.tensor([[True, False, True, False]])
+
+        weights = model.forward_attention_weights(inputs, mask=mask, rope_seed=7)["layer_0"]
+
+        assert weights.shape == (1, 2, 5, 2, 2)
+        assert_close(weights[..., 0, 1], torch.zeros_like(weights[..., 0, 1]))
+        assert_close(weights[..., 1, 1], torch.zeros_like(weights[..., 1, 1]))
+
     def test_quantization(self, device, config):
         torch.random.manual_seed(0)
         D = config.hidden_size

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,23 @@ wheels = [
 ]
 
 [[package]]
+name = "captum"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "torch" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/9e/f31758e20c3d2b42b05420936b75f663e7aeae9ba63b84aee5cad1b044a3/captum-0.9.0.tar.gz", hash = "sha256:e4868e22b68224f1a5355d2b7966803c021cf9fe5d893f51f587b4002a666b54", size = 363381, upload-time = "2026-04-17T06:11:39.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/75/c99571fee171bb9d34d3e1df5fdb16d57e2c4c15339eb220e6e6e4539f1c/captum-0.9.0-py3-none-any.whl", hash = "sha256:cda38e1d42c37591d71560bb2f5813ac4cae8d8543afac45279c7efd5945997e", size = 455196, upload-time = "2026-04-17T06:11:38.229Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1430,6 +1447,11 @@ benchmarking = [
     { name = "matplotlib" },
     { name = "tqdm" },
 ]
+explainability = [
+    { name = "captum" },
+    { name = "matplotlib" },
+    { name = "pillow" },
+]
 
 [package.dev-dependencies]
 benchmarking = [
@@ -1438,9 +1460,11 @@ benchmarking = [
 ]
 dev = [
     { name = "basedpyright" },
+    { name = "captum" },
     { name = "coverage" },
     { name = "matplotlib" },
     { name = "pdbpp" },
+    { name = "pillow" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
@@ -1448,18 +1472,26 @@ dev = [
     { name = "ruff" },
     { name = "tqdm" },
 ]
+explainability = [
+    { name = "captum" },
+    { name = "matplotlib" },
+    { name = "pillow" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "captum", marker = "extra == 'explainability'", specifier = "==0.9.0" },
     { name = "matplotlib", marker = "extra == 'benchmarking'", specifier = "==3.11.0" },
+    { name = "matplotlib", marker = "extra == 'explainability'", specifier = "==3.11.0" },
     { name = "numpy", marker = "python_full_version < '3.12'", specifier = "==2.4.6" },
     { name = "numpy", marker = "python_full_version >= '3.12'", specifier = "==2.5.1" },
+    { name = "pillow", marker = "extra == 'explainability'", specifier = "==12.3.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "torch", specifier = "==2.13.0" },
     { name = "torchao", specifier = "==0.17.0" },
     { name = "tqdm", marker = "extra == 'benchmarking'", specifier = "==4.68.4" },
 ]
-provides-extras = ["benchmarking"]
+provides-extras = ["benchmarking", "explainability"]
 
 [package.metadata.requires-dev]
 benchmarking = [
@@ -1468,13 +1500,20 @@ benchmarking = [
 ]
 dev = [
     { name = "basedpyright", specifier = "==1.39.9" },
+    { name = "captum", specifier = "==0.9.0" },
     { name = "coverage", specifier = "==7.15.0" },
     { name = "matplotlib", specifier = "==3.11.0" },
     { name = "pdbpp", specifier = "==0.12.1" },
+    { name = "pillow", specifier = "==12.3.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-env", specifier = "==1.6.0" },
     { name = "pytest-mock", specifier = "==3.15.1" },
     { name = "ruff", specifier = "==0.15.21" },
     { name = "tqdm", specifier = "==4.68.4" },
+]
+explainability = [
+    { name = "captum", specifier = "==0.9.0" },
+    { name = "matplotlib", specifier = "==3.11.0" },
+    { name = "pillow", specifier = "==12.3.0" },
 ]

--- a/vit/explain/__init__.py
+++ b/vit/explain/__init__.py
@@ -1,0 +1,82 @@
+"""Python-first explainability tools for native two-dimensional ViTs."""
+
+from .artifacts import load_explanation, save_explanation
+from .evaluation import (
+    Completeness,
+    DeletionInsertion,
+    EvaluationMetric,
+    Infidelity,
+    Localization,
+    ParameterRandomizationSanity,
+    SaCo,
+    Sensitivity,
+)
+from .explainer import ViTExplainer
+from .methods import (
+    AttentionRollout,
+    AttributionMethod,
+    GradientAttentionRollout,
+    InputXGradient,
+    IntegratedGradients,
+    LayerGradCAM,
+    LeGrad,
+    PatchOcclusion,
+    RawAttention,
+    Saliency,
+    SmoothGrad,
+)
+from .types import (
+    ActivationAtlas,
+    EvaluationReport,
+    Explanation,
+    ForwardArgs,
+    Intervention,
+    InterventionResult,
+    InterventionSite,
+    LayerTrace,
+    MetricResult,
+    TokenLayout,
+    TraceConfig,
+    ViTTrace,
+)
+from .visualization import interpolate_token_attribution, normalize_attribution
+
+
+__all__ = [
+    "ActivationAtlas",
+    "AttentionRollout",
+    "AttributionMethod",
+    "Completeness",
+    "DeletionInsertion",
+    "EvaluationReport",
+    "EvaluationMetric",
+    "Explanation",
+    "ForwardArgs",
+    "GradientAttentionRollout",
+    "InputXGradient",
+    "IntegratedGradients",
+    "Infidelity",
+    "interpolate_token_attribution",
+    "Intervention",
+    "InterventionSite",
+    "InterventionResult",
+    "LayerTrace",
+    "LayerGradCAM",
+    "LeGrad",
+    "Localization",
+    "MetricResult",
+    "ParameterRandomizationSanity",
+    "PatchOcclusion",
+    "RawAttention",
+    "load_explanation",
+    "Saliency",
+    "SaCo",
+    "Sensitivity",
+    "save_explanation",
+    "SmoothGrad",
+    "normalize_attribution",
+    "TokenLayout",
+    "TraceConfig",
+    "ViTExplainer",
+    "ViTTrace",
+]

--- a/vit/explain/artifacts.py
+++ b/vit/explain/artifacts.py
@@ -1,0 +1,297 @@
+"""Safe, deterministic-metadata explanation artifacts."""
+
+import json
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any, cast
+from zipfile import BadZipFile
+
+import numpy as np
+import torch
+
+from .types import Explanation, TokenLayout
+
+
+ARTIFACT_VERSION = 1
+_INTEGER_DTYPES = {
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.uint8,
+}
+
+
+def _metadata_path(path: Path) -> Path:
+    return path.with_suffix(".json")
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, torch.dtype):
+        return str(value)
+    raise TypeError(f"artifact metadata does not support {type(value).__name__}")
+
+
+def _temporary_path(directory: Path, prefix: str) -> Path:
+    with NamedTemporaryFile(dir=directory, prefix=prefix, suffix=".tmp", delete=False) as temporary_file:
+        return Path(temporary_file.name)
+
+
+def _replace_artifact_pair(temporary_paths: tuple[Path, Path], destination_paths: tuple[Path, Path]) -> None:
+    backups: dict[Path, Path] = {}
+    installed: list[Path] = []
+    try:
+        for destination in destination_paths:
+            if destination.exists():
+                backup = _temporary_path(destination.parent, f".{destination.name}.backup-")
+                backup.unlink()
+                destination.replace(backup)
+                backups[destination] = backup
+        for temporary, destination in zip(temporary_paths, destination_paths, strict=True):
+            temporary.replace(destination)
+            installed.append(destination)
+    except Exception:
+        for destination in installed:
+            destination.unlink(missing_ok=True)
+        for destination, backup in backups.items():
+            if backup.exists():
+                backup.replace(destination)
+        raise
+    else:
+        for backup in backups.values():
+            backup.unlink(missing_ok=True)
+
+
+def _validate_explanation(explanation: Explanation, *, loaded: bool = False) -> None:
+    prefix = "malformed artifact: " if loaded else ""
+
+    def fail(message: str) -> None:
+        raise ValueError(prefix + message)
+
+    layout = explanation.layout
+    if any(value <= 0 for value in (*layout.grid_size, *layout.patch_size, *layout.original_size)):
+        fail("grid_size, patch_size, and original_size must be positive")
+    expected_modeled_size = (
+        layout.grid_size[0] * layout.patch_size[0],
+        layout.grid_size[1] * layout.patch_size[1],
+    )
+    if layout.modeled_size != expected_modeled_size:
+        fail(f"modeled_size must equal grid_size * patch_size, got {layout.modeled_size}")
+    if any(modeled > original for modeled, original in zip(layout.modeled_size, layout.original_size, strict=True)):
+        fail("modeled_size cannot exceed original_size")
+    if layout.num_cls_tokens < 0 or layout.num_register_tokens < 0:
+        fail("prefix token counts must be nonnegative")
+
+    token_count = layout.visual_token_count
+    token_attributions = explanation.token_attributions
+    if token_attributions.ndim != 2 or token_attributions.shape[1] != token_count:
+        fail(f"token_attributions must have shape (batch, {token_count})")
+    if not token_attributions.is_floating_point():
+        fail("token_attributions must use a floating-point dtype")
+    batch_size = token_attributions.shape[0]
+    if batch_size <= 0:
+        fail("explanation batch size must be positive")
+    if explanation.target_scores.shape != (batch_size,):
+        fail(f"target_scores must have shape ({batch_size},)")
+    if not explanation.target_scores.is_floating_point():
+        fail("target_scores must use a floating-point dtype")
+
+    visual_validity = layout.visual_validity
+    visual_indices = layout.visual_indices
+    if visual_validity.dtype != torch.bool or visual_validity.shape != (batch_size, token_count):
+        fail(f"visual_validity must be bool with shape ({batch_size}, {token_count})")
+    if visual_indices.dtype not in _INTEGER_DTYPES or visual_indices.ndim != 2 or visual_indices.shape[0] != batch_size:
+        fail("visual_indices must be a two-dimensional integer tensor with the explanation batch size")
+    maximum_sequence_length = int(visual_validity.sum(dim=1).max().item())
+    if visual_indices.shape[1] != maximum_sequence_length:
+        fail("visual_indices length must equal the largest valid visual-token count")
+    for batch_index in range(batch_size):
+        expected_indices = torch.nonzero(visual_validity[batch_index], as_tuple=False).flatten().cpu()
+        padding = torch.full(
+            (maximum_sequence_length - expected_indices.numel(),),
+            -1,
+            dtype=expected_indices.dtype,
+        )
+        expected_row = torch.cat((expected_indices, padding))
+        if not torch.equal(visual_indices[batch_index].cpu().to(expected_row.dtype), expected_row):
+            fail("visual_indices do not match visual_validity")
+
+    if explanation.pixel_attributions is not None:
+        pixel_attributions = explanation.pixel_attributions
+        expected_pixel_shape = (batch_size, *layout.original_size)
+        if (
+            pixel_attributions.ndim != 4
+            or pixel_attributions.shape[0] != batch_size
+            or pixel_attributions.shape[-2:] != layout.original_size
+        ):
+            fail(
+                f"pixel_attributions must have shape (batch, channels, {expected_pixel_shape[-2]}, {expected_pixel_shape[-1]})"
+            )
+        if not pixel_attributions.is_floating_point():
+            fail("pixel_attributions must use a floating-point dtype")
+    for index, attribution in enumerate(explanation.layer_attributions):
+        if attribution.shape != token_attributions.shape or not attribution.is_floating_point():
+            fail(f"layer_attributions[{index}] must match token_attributions shape and dtype kind")
+
+
+def _artifact_arrays(explanation: Explanation) -> tuple[dict[str, np.ndarray], dict[str, str]]:
+    tensors = {
+        "target_scores": explanation.target_scores,
+        "token_attributions": explanation.token_attributions,
+        "visual_indices": explanation.layout.visual_indices,
+        "visual_validity": explanation.layout.visual_validity,
+    }
+    if explanation.pixel_attributions is not None:
+        tensors["pixel_attributions"] = explanation.pixel_attributions
+    tensors.update(
+        {f"layer_attributions_{index:04d}": value for index, value in enumerate(explanation.layer_attributions)}
+    )
+    arrays: dict[str, np.ndarray] = {}
+    stored_dtypes: dict[str, str] = {}
+    for name, tensor in tensors.items():
+        stored = tensor.detach().cpu()
+        if stored.dtype == torch.bfloat16:
+            stored_dtypes[name] = str(stored.dtype)
+            stored = stored.float()
+        try:
+            arrays[name] = stored.numpy()
+        except TypeError as error:
+            raise TypeError(f"artifact array {name} uses unsupported dtype {tensor.dtype}") from error
+    return arrays, stored_dtypes
+
+
+def save_explanation(explanation: Explanation, path: str | Path, *, overwrite: bool = False) -> None:
+    """Write numeric arrays to NPZ and deterministic, non-pickle metadata to JSON."""
+    array_path = Path(path)
+    if array_path.suffix != ".npz":
+        raise ValueError("explanation artifact path must end in .npz")
+    metadata_path = _metadata_path(array_path)
+    existing = [candidate for candidate in (array_path, metadata_path) if candidate.exists()]
+    if existing and not overwrite:
+        raise FileExistsError(f"artifact exists; pass overwrite=True to replace {existing[0]}")
+    _validate_explanation(explanation)
+    arrays, stored_dtypes = _artifact_arrays(explanation)
+    metadata = {
+        "array_dtypes": stored_dtypes,
+        "artifact_version": ARTIFACT_VERSION,
+        "configuration": _json_value(dict(explanation.configuration)),
+        "kind": "vit.explain.Explanation",
+        "layer_count": len(explanation.layer_attributions),
+        "layout": {
+            "grid_size": list(explanation.layout.grid_size),
+            "modeled_size": list(explanation.layout.modeled_size),
+            "num_cls_tokens": explanation.layout.num_cls_tokens,
+            "num_register_tokens": explanation.layout.num_register_tokens,
+            "original_size": list(explanation.layout.original_size),
+            "patch_size": list(explanation.layout.patch_size),
+        },
+        "method": explanation.method,
+    }
+    metadata_text = json.dumps(metadata, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    array_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_array = _temporary_path(array_path.parent, f".{array_path.name}.")
+    temporary_metadata = _temporary_path(metadata_path.parent, f".{metadata_path.name}.")
+    try:
+        with temporary_array.open("wb") as artifact_file:
+            save_arrays = cast(Any, np.savez_compressed)
+            save_arrays(artifact_file, **dict(sorted(arrays.items())))
+        temporary_metadata.write_text(metadata_text)
+        _replace_artifact_pair(
+            (temporary_array, temporary_metadata),
+            (array_path, metadata_path),
+        )
+    finally:
+        temporary_array.unlink(missing_ok=True)
+        temporary_metadata.unlink(missing_ok=True)
+
+
+def _pair(value: Any, name: str) -> tuple[int, int]:
+    if not isinstance(value, list) or len(value) != 2 or not all(type(item) is int for item in value):
+        raise ValueError(f"malformed artifact: {name} must contain two integers")
+    return int(value[0]), int(value[1])
+
+
+def _nonnegative_int(value: Any, name: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"malformed artifact: {name} must be a nonnegative integer")
+    return value
+
+
+def load_explanation(path: str | Path) -> Explanation:
+    """Load an explanation with NumPy pickle loading explicitly disabled."""
+    array_path = Path(path)
+    metadata_path = _metadata_path(array_path)
+    try:
+        metadata = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not read artifact metadata {metadata_path}: {error}") from error
+    if not isinstance(metadata, dict):
+        raise ValueError("unsupported or malformed explanation artifact metadata")
+    if metadata.get("artifact_version") != ARTIFACT_VERSION or metadata.get("kind") != "vit.explain.Explanation":
+        raise ValueError("unsupported or malformed explanation artifact metadata")
+    try:
+        with np.load(array_path, allow_pickle=False) as stored:
+            arrays = {name: torch.from_numpy(stored[name].copy()) for name in stored.files}
+    except (OSError, TypeError, ValueError, KeyError, BadZipFile) as error:
+        raise ValueError(f"could not read artifact arrays {array_path}: {error}") from error
+    required = {"target_scores", "token_attributions", "visual_indices", "visual_validity"}
+    if not required <= arrays.keys():
+        raise ValueError(f"malformed artifact: missing arrays {sorted(required - arrays.keys())}")
+    layer_count = metadata.get("layer_count", 0)
+    layer_count = _nonnegative_int(layer_count, "layer_count")
+    expected_arrays = required | {f"layer_attributions_{index:04d}" for index in range(layer_count)}
+    if "pixel_attributions" in arrays:
+        expected_arrays.add("pixel_attributions")
+    if unexpected := arrays.keys() - expected_arrays:
+        raise ValueError(f"malformed artifact: unexpected arrays {sorted(unexpected)}")
+
+    stored_dtypes = metadata.get("array_dtypes", {})
+    if not isinstance(stored_dtypes, dict) or not all(
+        isinstance(name, str) and isinstance(dtype, str) for name, dtype in stored_dtypes.items()
+    ):
+        raise ValueError("malformed artifact: array_dtypes must map array names to dtype strings")
+    for name, dtype in stored_dtypes.items():
+        if name not in arrays or dtype != str(torch.bfloat16) or arrays[name].dtype != torch.float32:
+            raise ValueError(f"malformed artifact: invalid stored dtype for {name}")
+        arrays[name] = arrays[name].to(torch.bfloat16)
+
+    layout_metadata = metadata.get("layout")
+    if not isinstance(layout_metadata, dict):
+        raise ValueError("malformed artifact: layout metadata is missing")
+    layout = TokenLayout(
+        grid_size=_pair(layout_metadata.get("grid_size"), "grid_size"),
+        patch_size=_pair(layout_metadata.get("patch_size"), "patch_size"),
+        original_size=_pair(layout_metadata.get("original_size"), "original_size"),
+        modeled_size=_pair(layout_metadata.get("modeled_size"), "modeled_size"),
+        num_cls_tokens=_nonnegative_int(layout_metadata.get("num_cls_tokens", 0), "num_cls_tokens"),
+        num_register_tokens=_nonnegative_int(
+            layout_metadata.get("num_register_tokens", 0),
+            "num_register_tokens",
+        ),
+        visual_indices=arrays["visual_indices"],
+        visual_validity=arrays["visual_validity"],
+    )
+    try:
+        layer_attributions = tuple(arrays[f"layer_attributions_{index:04d}"] for index in range(layer_count))
+    except KeyError as error:
+        raise ValueError(f"malformed artifact: missing {error.args[0]}") from error
+    configuration = metadata.get("configuration", {})
+    if not isinstance(configuration, dict) or not isinstance(metadata.get("method"), str):
+        raise ValueError("malformed artifact: method or configuration is invalid")
+    explanation = Explanation(
+        method=metadata["method"],
+        token_attributions=arrays["token_attributions"],
+        pixel_attributions=arrays.get("pixel_attributions"),
+        target_scores=arrays["target_scores"],
+        layout=layout,
+        layer_attributions=layer_attributions,
+        configuration=configuration,
+    )
+    _validate_explanation(explanation, loaded=True)
+    return explanation

--- a/vit/explain/cli.py
+++ b/vit/explain/cli.py
@@ -1,0 +1,173 @@
+"""Inspect, render, and compare saved explainability artifacts."""
+
+import argparse
+import json
+import math
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import torch
+
+from .artifacts import load_explanation
+from .visualization import Normalization, interpolate_token_attribution
+
+
+@dataclass(frozen=True)
+class _Styles:
+    enabled: bool
+
+    def label(self, value: str) -> str:
+        return f"\x1b[36m{value}\x1b[0m" if self.enabled else value
+
+    def value(self, value: Any) -> str:
+        rendered = str(value)
+        return f"\x1b[33m{rendered}\x1b[0m" if self.enabled else rendered
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect, render, and compare vit.explain artifacts.")
+    parser.add_argument("--format", choices=("text", "json"), default="text", help="Report output format")
+    parser.add_argument("--color", choices=("auto", "always", "never"), default="auto", help="Color policy")
+    parser.add_argument("--no-color", action="store_true", help="Disable color output")
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument("--quiet", action="store_true", help="Suppress nonessential status output")
+    verbosity.add_argument("--verbose", action="store_true", help="Write diagnostic details to stderr")
+    parser.add_argument(
+        "--progress",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help="Progress display policy",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    inspect_parser = subparsers.add_parser("inspect", help="Summarize an explanation artifact")
+    inspect_parser.add_argument("artifact", type=Path)
+    render_parser = subparsers.add_parser("render", help="Render one attribution map")
+    render_parser.add_argument("artifact", type=Path)
+    render_parser.add_argument("output", type=Path)
+    render_parser.add_argument("--batch-index", type=int, default=0)
+    render_parser.add_argument(
+        "--normalization",
+        choices=("none", "minmax", "symmetric", "absolute"),
+        default="minmax",
+    )
+    render_parser.add_argument("--overwrite", action="store_true")
+    compare_parser = subparsers.add_parser("compare", help="Compare two attribution artifacts")
+    compare_parser.add_argument("first", type=Path)
+    compare_parser.add_argument("second", type=Path)
+    return parser
+
+
+def _summary(explanation) -> dict[str, Any]:
+    return {
+        "configuration": dict(explanation.configuration),
+        "grid_size": list(explanation.layout.grid_size),
+        "has_pixel_attributions": explanation.pixel_attributions is not None,
+        "layer_count": len(explanation.layer_attributions),
+        "method": explanation.method,
+        "modeled_size": list(explanation.layout.modeled_size),
+        "original_size": list(explanation.layout.original_size),
+        "target_scores_shape": list(explanation.target_scores.shape),
+        "token_attributions_shape": list(explanation.token_attributions.shape),
+    }
+
+
+def _color_enabled(output_format: str, color: str, no_color: bool) -> bool:
+    if no_color or output_format != "text" or color == "never":
+        return False
+    return color == "always" or sys.stdout.isatty()
+
+
+def _progress_enabled(output_format: str, progress: str, quiet: bool) -> bool:
+    if quiet or progress == "never":
+        return False
+    if progress == "always":
+        return True
+    return output_format == "text" and sys.stderr.isatty()
+
+
+def _write_progress(command: str, enabled: bool) -> None:
+    if enabled:
+        print(f"vit-explain: {command} [1/1]", file=sys.stderr)
+
+
+def _write_report(payload: dict[str, Any], output_format: str, styles: _Styles) -> None:
+    if output_format == "json":
+        print(json.dumps(payload, sort_keys=True, allow_nan=False))
+        return
+    for name, value in payload.items():
+        print(f"{styles.label(name)}: {styles.value(value)}")
+
+
+def _compare(first, second) -> dict[str, Any]:
+    if not first.layout.matches(second.layout):
+        raise ValueError("artifacts have different token layouts")
+    if first.token_attributions.shape != second.token_attributions.shape:
+        raise ValueError("artifacts have different token-attribution shapes")
+    first_values = first.token_attributions.nan_to_num().flatten().float()
+    second_values = second.token_attributions.nan_to_num().flatten().float()
+    cosine = float(torch.nn.functional.cosine_similarity(first_values[None], second_values[None]).item())
+    difference = first_values - second_values
+    return {
+        "cosine_similarity": cosine if math.isfinite(cosine) else 0.0,
+        "max_absolute_difference": float(difference.abs().max().item()),
+        "mean_absolute_difference": float(difference.abs().mean().item()),
+    }
+
+
+def _render(explanation, output: Path, batch_index: int, normalization: str, overwrite: bool) -> None:
+    if output.exists() and not overwrite:
+        raise FileExistsError(f"output exists; pass --overwrite to replace {output}")
+    if batch_index < 0 or batch_index >= explanation.token_attributions.shape[0]:
+        raise ValueError(f"batch index must be in [0, {explanation.token_attributions.shape[0]})")
+    try:
+        import matplotlib.pyplot as plt
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "rendering requires the explainability extra: pip install 'vit[explainability]'",
+            name="matplotlib",
+        ) from None
+    output.parent.mkdir(parents=True, exist_ok=True)
+    image = (
+        interpolate_token_attribution(explanation, normalization=cast(Normalization, normalization))[batch_index]
+        .float()
+        .numpy()
+    )
+    color_map = plt.get_cmap("coolwarm" if normalization == "symmetric" else "viridis").with_extremes(bad="#777777")
+    plt.imsave(output, image, cmap=color_map)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the artifact-only explainability CLI."""
+    parser = _parser()
+    args = parser.parse_args(argv)
+    styles = _Styles(_color_enabled(args.format, args.color, args.no_color))
+    show_progress = _progress_enabled(args.format, args.progress, args.quiet)
+    try:
+        _write_progress(args.command, show_progress)
+        if args.command == "inspect":
+            explanation = load_explanation(args.artifact)
+            _write_report(_summary(explanation), args.format, styles)
+        elif args.command == "compare":
+            first = load_explanation(args.first)
+            second = load_explanation(args.second)
+            _write_report(_compare(first, second), args.format, styles)
+        elif args.command == "render":
+            explanation = load_explanation(args.artifact)
+            _render(explanation, args.output, args.batch_index, args.normalization, args.overwrite)
+            if not args.quiet:
+                _write_report({"output": str(args.output)}, args.format, styles)
+        else:  # pragma: no cover - argparse enforces a subcommand
+            parser.error(f"unknown command {args.command}")
+        if args.verbose:
+            print(f"vit-explain: completed {args.command}", file=sys.stderr)
+        return 0
+    except (OSError, RuntimeError, TypeError, ValueError, ModuleNotFoundError) as error:
+        print(f"vit-explain failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/vit/explain/evaluation.py
+++ b/vit/explain/evaluation.py
@@ -1,0 +1,385 @@
+"""Faithfulness, robustness, completeness, localization, and sanity metrics."""
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+import torch
+from torch import Tensor
+
+from .trace import make_token_layout, preserve_explainer_state
+from .types import EvaluationReport, Explanation, ForwardArgs, MetricResult, Target, select_targets
+
+
+if TYPE_CHECKING:
+    from .explainer import ViTExplainer
+    from .methods import AttributionMethod
+
+
+class EvaluationMetric(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    def evaluate(
+        self,
+        explainer: "ViTExplainer",
+        inputs: Tensor,
+        explanation: Explanation,
+        target: Target | None,
+        forward_args: ForwardArgs,
+    ) -> MetricResult: ...
+
+
+def _scores(explainer: "ViTExplainer", inputs: Tensor, target: Target | None, forward_args: ForwardArgs) -> Tensor:
+    features = explainer.model(
+        inputs,
+        mask=forward_args.mask,
+        rope_seed=forward_args.rope_seed,
+        output_norm=forward_args.output_norm,
+        conditioning=forward_args.conditioning,
+    )
+    return select_targets(explainer.output_fn(features), target)
+
+
+def _baseline(inputs: Tensor, value: Tensor | float) -> Tensor:
+    baseline = torch.as_tensor(value, device=inputs.device, dtype=inputs.dtype)
+    return baseline.expand_as(inputs) if baseline.numel() != inputs.numel() else baseline.reshape_as(inputs)
+
+
+def _token_values_and_validity(explanation: Explanation) -> tuple[Tensor, Tensor]:
+    values = explanation.token_attributions
+    validity = explanation.layout.visual_validity.to(device=values.device)
+    if validity.shape != values.shape:
+        raise ValueError("token attribution shape does not match layout validity")
+    if not validity.any(dim=1).all():
+        raise ValueError("evaluation requires at least one valid visual token per example")
+    if not torch.isfinite(values[validity]).all():
+        raise ValueError("attributions for valid visual tokens must be finite")
+    return values, validity
+
+
+def _pixel_validity(explanation: Explanation, inputs: Tensor) -> Tensor:
+    _, token_validity = _token_values_and_validity(explanation)
+    grid_height, grid_width = explanation.layout.grid_size
+    patch_height, patch_width = explanation.layout.patch_size
+    modeled_height, modeled_width = explanation.layout.modeled_size
+    patch_validity = token_validity.view(-1, 1, grid_height, grid_width)
+    modeled_validity = patch_validity.repeat_interleave(patch_height, dim=2).repeat_interleave(patch_width, dim=3)
+    validity = torch.zeros(
+        (inputs.shape[0], 1, inputs.shape[-2], inputs.shape[-1]),
+        dtype=torch.bool,
+        device=inputs.device,
+    )
+    validity[..., :modeled_height, :modeled_width] = modeled_validity.to(device=inputs.device)
+    return validity
+
+
+def _replace_patches(
+    destination: Tensor,
+    source: Tensor,
+    patch_indices: Tensor,
+    batch_index: int,
+    patch_size: tuple[int, int],
+    grid_width: int,
+) -> None:
+    patch_height, patch_width = patch_size
+    for index in patch_indices.tolist():
+        row, column = divmod(int(index), grid_width)
+        row_slice = slice(row * patch_height, (row + 1) * patch_height)
+        column_slice = slice(column * patch_width, (column + 1) * patch_width)
+        destination[batch_index, :, row_slice, column_slice] = source[batch_index, :, row_slice, column_slice]
+
+
+def saco_score(importance: Tensor, score_changes: Tensor) -> Tensor:
+    """Return pairwise signed concordance between group relevance and causal score changes."""
+    if importance.shape != score_changes.shape or importance.ndim != 2:
+        raise ValueError("SaCo importance and score changes must have matching (batch, groups) shapes")
+    importance_delta = importance[:, :, None] - importance[:, None, :]
+    score_delta = score_changes[:, :, None] - score_changes[:, None, :]
+    upper = torch.triu(torch.ones_like(importance_delta, dtype=torch.bool), diagonal=1)
+    comparable = upper & (importance_delta != 0) & (score_delta != 0)
+    concordance = (importance_delta.sign() * score_delta.sign()).where(comparable, 0)
+    count = comparable.sum(dim=(1, 2))
+    return concordance.sum(dim=(1, 2)) / count.clamp_min(1)
+
+
+@dataclass(frozen=True)
+class DeletionInsertion:
+    """Patch deletion and insertion curves ranked by attribution magnitude."""
+
+    steps: int = 10
+    baseline: Tensor | float = 0.0
+    name: str = "deletion_insertion"
+
+    def evaluate(self, explainer, inputs, explanation, target, forward_args) -> MetricResult:
+        if self.steps <= 0:
+            raise ValueError("deletion/insertion steps must be positive")
+        token_values, validity = _token_values_and_validity(explanation)
+        ranking = token_values.abs().masked_fill(~validity, -torch.inf).argsort(dim=1, descending=True)
+        baseline = _baseline(inputs, self.baseline)
+        normalized_steps = torch.linspace(0, 1, self.steps + 1, device=inputs.device)
+        valid_counts = validity.sum(dim=1)
+        counts = (normalized_steps[:, None] * valid_counts.to(device=inputs.device)).round().long()
+        deletion_values: list[Tensor] = []
+        insertion_values: list[Tensor] = []
+        with preserve_explainer_state(explainer), torch.no_grad():
+            for step_counts in counts.tolist():
+                deleted = inputs.clone()
+                inserted = baseline.clone()
+                for batch_index, count in enumerate(step_counts):
+                    selected = ranking[batch_index, :count]
+                    _replace_patches(
+                        deleted,
+                        baseline,
+                        selected,
+                        batch_index,
+                        explanation.layout.patch_size,
+                        explanation.layout.grid_size[1],
+                    )
+                    _replace_patches(
+                        inserted,
+                        inputs,
+                        selected,
+                        batch_index,
+                        explanation.layout.patch_size,
+                        explanation.layout.grid_size[1],
+                    )
+                deletion_values.append(_scores(explainer, deleted, target, forward_args))
+                insertion_values.append(_scores(explainer, inserted, target, forward_args))
+        curves = torch.stack((torch.stack(deletion_values, 1), torch.stack(insertion_values, 1)), dim=1)
+        normalized_steps = normalized_steps.to(dtype=curves.dtype)
+        metadata = {
+            "deletion_auc": torch.trapezoid(curves[:, 0], normalized_steps, dim=1).detach(),
+            "insertion_auc": torch.trapezoid(curves[:, 1], normalized_steps, dim=1).detach(),
+        }
+        return MetricResult(self.name, curves.detach(), metadata)
+
+
+@dataclass(frozen=True)
+class SaCo:
+    """Signed causal-order concordance across independently ablated relevance groups."""
+
+    groups: int = 10
+    baseline: Tensor | float = 0.0
+    name: str = "saco"
+
+    def evaluate(self, explainer, inputs, explanation, target, forward_args) -> MetricResult:
+        token_values, validity = _token_values_and_validity(explanation)
+        valid_counts = validity.sum(dim=1)
+        group_count = min(self.groups, int(valid_counts.min().item()))
+        if group_count < 2:
+            raise ValueError("SaCo requires at least two groups")
+        ranking = token_values.masked_fill(~validity, -torch.inf).argsort(dim=1, descending=True)
+        batch_groups = tuple(
+            torch.tensor_split(ranking[batch_index, : int(valid_counts[batch_index].item())], group_count)
+            for batch_index in range(inputs.shape[0])
+        )
+        baseline = _baseline(inputs, self.baseline)
+        importance = torch.stack(
+            [
+                torch.stack(
+                    [
+                        token_values[batch_index, batch_groups[batch_index][group_index]].sum()
+                        for batch_index in range(inputs.shape[0])
+                    ]
+                )
+                for group_index in range(group_count)
+            ],
+            dim=1,
+        )
+        with preserve_explainer_state(explainer), torch.no_grad():
+            original_scores = _scores(explainer, inputs, target, forward_args)
+            changes: list[Tensor] = []
+            for group_index in range(group_count):
+                ablated = inputs.clone()
+                for batch_index in range(inputs.shape[0]):
+                    _replace_patches(
+                        ablated,
+                        baseline,
+                        batch_groups[batch_index][group_index],
+                        batch_index,
+                        explanation.layout.patch_size,
+                        explanation.layout.grid_size[1],
+                    )
+                changes.append(original_scores - _scores(explainer, ablated, target, forward_args))
+        score_changes = torch.stack(changes, dim=1)
+        return MetricResult(
+            self.name,
+            saco_score(importance, score_changes).detach(),
+            {"group_importance": importance.detach(), "score_changes": score_changes.detach()},
+        )
+
+
+@dataclass(frozen=True)
+class Infidelity:
+    """Expected squared mismatch between attribution response and output response."""
+
+    samples: int = 20
+    noise_scale: float = 0.01
+    seed: int = 0
+    name: str = "infidelity"
+
+    def evaluate(self, explainer, inputs, explanation, target, forward_args) -> MetricResult:
+        if self.samples <= 0:
+            raise ValueError("infidelity samples must be positive")
+        token_values, validity = _token_values_and_validity(explanation)
+        generator = torch.Generator(device=inputs.device).manual_seed(self.seed)
+        errors: list[Tensor] = []
+        with preserve_explainer_state(explainer), torch.no_grad():
+            original = _scores(explainer, inputs, target, forward_args)
+            for _ in range(self.samples):
+                perturbation = torch.randn(inputs.shape, generator=generator, device=inputs.device, dtype=inputs.dtype)
+                perturbation = perturbation * self.noise_scale
+                changed = _scores(explainer, inputs - perturbation, target, forward_args)
+                if explanation.pixel_attributions is not None:
+                    if explanation.pixel_attributions.shape != inputs.shape:
+                        raise ValueError("pixel attribution shape must match inputs")
+                    pixel_validity = _pixel_validity(explanation, inputs)
+                    pixel_values = explanation.pixel_attributions.where(pixel_validity, 0)
+                    estimated = (pixel_values * perturbation).flatten(1).sum(1)
+                else:
+                    patch_height, patch_width = explanation.layout.patch_size
+                    patch_noise = (
+                        perturbation[..., : explanation.layout.modeled_size[0], : explanation.layout.modeled_size[1]]
+                        .unfold(2, patch_height, patch_height)
+                        .unfold(3, patch_width, patch_width)
+                    )
+                    patch_noise = patch_noise.mean(dim=(1, -1, -2)).flatten(1)
+                    estimated = (token_values.where(validity, 0) * patch_noise).sum(1)
+                errors.append((estimated - (original - changed)).square())
+        return MetricResult(self.name, torch.stack(errors).mean(0).detach())
+
+
+@dataclass(frozen=True)
+class Sensitivity:
+    """Maximum attribution change under bounded Gaussian input perturbations."""
+
+    method: "AttributionMethod"
+    samples: int = 8
+    radius: float = 0.01
+    seed: int = 0
+    name: str = "sensitivity"
+
+    def evaluate(self, explainer, inputs, explanation, target, forward_args) -> MetricResult:
+        if self.samples <= 0:
+            raise ValueError("sensitivity samples must be positive")
+        token_values, validity = _token_values_and_validity(explanation)
+        generator = torch.Generator(device=inputs.device).manual_seed(self.seed)
+        changes: list[Tensor] = []
+        for _ in range(self.samples):
+            noise = torch.randn(inputs.shape, generator=generator, device=inputs.device, dtype=inputs.dtype)
+            perturbed = explainer.attribute(
+                inputs + noise * self.radius,
+                target=target,
+                method=self.method,
+                forward_args=forward_args,
+            )
+            perturbed_values, perturbed_validity = _token_values_and_validity(perturbed)
+            if not torch.equal(validity, perturbed_validity):
+                raise ValueError("sensitivity explanations must share one token validity layout")
+            difference = (perturbed_values - token_values).abs().where(validity, 0)
+            changes.append(difference.flatten(1).amax(1))
+        return MetricResult(self.name, torch.stack(changes).amax(0).detach())
+
+
+@dataclass(frozen=True)
+class Completeness:
+    """Absolute residual in the attribution-sum completeness equation."""
+
+    baseline: Tensor | float = 0.0
+    name: str = "completeness"
+
+    def evaluate(self, explainer, inputs, explanation, target, forward_args) -> MetricResult:
+        baseline = _baseline(inputs, self.baseline)
+        with preserve_explainer_state(explainer), torch.no_grad():
+            score_difference = _scores(explainer, inputs, target, forward_args) - _scores(
+                explainer, baseline, target, forward_args
+            )
+        if explanation.pixel_attributions is None:
+            token_values, validity = _token_values_and_validity(explanation)
+            attribution_sum = token_values.where(validity, 0).sum(1)
+        else:
+            pixel_validity = _pixel_validity(explanation, inputs)
+            attribution_sum = explanation.pixel_attributions.where(pixel_validity, 0).flatten(1).sum(1)
+        return MetricResult(self.name, (attribution_sum - score_difference).abs().detach())
+
+
+@dataclass(frozen=True)
+class Localization:
+    """Pointing-game accuracy and positive relevance mass inside a supplied region."""
+
+    region: Tensor
+    name: str = "localization"
+
+    def evaluate(self, explainer, inputs, explanation, target, forward_args) -> MetricResult:
+        _ = explainer, inputs, target, forward_args
+        relevance, validity = _token_values_and_validity(explanation)
+        region = self.region.to(device=relevance.device, dtype=torch.bool)
+        if region.shape == (*relevance.shape[:-1], *explanation.layout.grid_size):
+            region = region.flatten(1)
+        if region.shape != relevance.shape:
+            raise ValueError(f"localization region must have shape {tuple(relevance.shape)} or the token grid")
+        peak = relevance.masked_fill(~validity, -torch.inf).argmax(1)
+        pointing = region.gather(1, peak[:, None]).squeeze(1).to(relevance.dtype)
+        positive = relevance.clamp_min(0).where(validity, 0)
+        mass = (positive * region).sum(1) / positive.sum(1).clamp_min(torch.finfo(positive.dtype).eps)
+        return MetricResult(self.name, torch.stack((pointing, mass), dim=1).detach())
+
+
+@dataclass(frozen=True)
+class ParameterRandomizationSanity:
+    """Centered cosine similarity after deterministic model-parameter randomization."""
+
+    method: "AttributionMethod"
+    seed: int = 0
+    name: str = "parameter_randomization"
+
+    def evaluate(self, explainer, inputs, explanation, target, forward_args) -> MetricResult:
+        state = deepcopy(explainer.model.state_dict())
+        devices = [inputs.device] if inputs.device.type == "cuda" else []
+        try:
+            with torch.random.fork_rng(devices=devices):
+                torch.manual_seed(self.seed)
+                for module in explainer.model.modules():
+                    reset = getattr(module, "reset_parameters", None)
+                    if callable(reset):
+                        reset()
+                randomized = explainer.attribute(
+                    inputs,
+                    target=target,
+                    method=self.method,
+                    forward_args=forward_args,
+                )
+        finally:
+            explainer.model.load_state_dict(state)
+        original_values, validity = _token_values_and_validity(explanation)
+        randomized_values, randomized_validity = _token_values_and_validity(randomized)
+        if not torch.equal(validity, randomized_validity):
+            raise ValueError("randomized explanations must share one token validity layout")
+        similarities: list[Tensor] = []
+        for batch_index in range(original_values.shape[0]):
+            valid = validity[batch_index]
+            original = original_values[batch_index, valid]
+            randomized_item = randomized_values[batch_index, valid]
+            original = original - original.mean()
+            randomized_item = randomized_item - randomized_item.mean()
+            similarities.append(torch.nn.functional.cosine_similarity(original, randomized_item, dim=0))
+        similarity = torch.stack(similarities)
+        return MetricResult(self.name, similarity.detach())
+
+
+def evaluate(
+    explainer: "ViTExplainer",
+    inputs: Tensor,
+    explanation: Explanation,
+    target: Target | None,
+    metrics: list[EvaluationMetric] | tuple[EvaluationMetric, ...],
+    forward_args: ForwardArgs,
+) -> EvaluationReport:
+    layout = make_token_layout(explainer.model, inputs, forward_args.mask)
+    if not layout.matches(explanation.layout):
+        raise ValueError("evaluation inputs and forward arguments must match the explanation token layout")
+    results = {metric.name: metric.evaluate(explainer, inputs, explanation, target, forward_args) for metric in metrics}
+    if len(results) != len(metrics):
+        raise ValueError("evaluation metric names must be unique")
+    return EvaluationReport(results)

--- a/vit/explain/experimental/__init__.py
+++ b/vit/explain/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental explainability systems without stable API guarantees."""

--- a/vit/explain/experimental/sparse.py
+++ b/vit/explain/experimental/sparse.py
@@ -1,0 +1,272 @@
+"""Float32 Top-K sparse autoencoders for streamed ViT residual activations."""
+
+import heapq
+import itertools
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..interventions import _site_tensor, _unpack_batch
+from ..trace import preserve_explainer_state, trace_vit
+from ..types import ActivationRecord, ForwardArgs, InterventionSite, TokenLayout, TraceConfig, ViTTrace
+
+
+@dataclass(frozen=True)
+class SparseMetrics:
+    reconstruction_mse: float
+    explained_variance: float
+    l0: float
+    dead_feature_rate: float
+    downstream_score_recovery: float | None = None
+
+
+@dataclass(frozen=True)
+class SparseFeatureAtlas:
+    top_k: int
+    features: dict[int, tuple[ActivationRecord, ...]]
+    layout: TokenLayout | None = None
+
+
+class TopKSparseAutoencoder(nn.Module):
+    """A separable Top-K dictionary with unit-norm decoded feature directions."""
+
+    def __init__(self, input_features: int, dictionary_features: int, k: int, *, device=None):
+        super().__init__()
+        if input_features <= 0 or dictionary_features <= 0:
+            raise ValueError("input and dictionary feature counts must be positive")
+        if k <= 0 or k > dictionary_features:
+            raise ValueError("k must be in [1, dictionary_features]")
+        self.input_features = input_features
+        self.dictionary_features = dictionary_features
+        self.k = k
+        self.encoder = nn.Linear(input_features, dictionary_features, dtype=torch.float32, device=device)
+        self.decoder = nn.Parameter(
+            torch.empty(dictionary_features, input_features, dtype=torch.float32, device=device)
+        )
+        self.decoder_bias = nn.Parameter(torch.zeros(input_features, dtype=torch.float32, device=device))
+        self.reset_parameters()
+
+    @property
+    def decoder_directions(self) -> Tensor:
+        return F.normalize(self.decoder, dim=1)
+
+    def reset_parameters(self) -> None:
+        self.encoder.reset_parameters()
+        nn.init.normal_(self.decoder, std=self.input_features**-0.5)
+        nn.init.zeros_(self.decoder_bias)
+        self.normalize_decoder_()
+
+    @torch.no_grad()
+    def normalize_decoder_(self) -> None:
+        self.decoder.copy_(self.decoder_directions)
+
+    def encode(self, inputs: Tensor) -> Tensor:
+        if inputs.dtype != torch.float32:
+            inputs = inputs.float()
+        preactivations = self.encoder(inputs - self.decoder_bias)
+        values, indices = preactivations.topk(self.k, dim=-1)
+        values = torch.where(values == 0, torch.full_like(values, torch.finfo(values.dtype).eps), values)
+        return torch.zeros_like(preactivations).scatter(-1, indices, values)
+
+    def decode(self, codes: Tensor) -> Tensor:
+        return codes @ self.decoder_directions + self.decoder_bias
+
+    def forward(self, inputs: Tensor) -> tuple[Tensor, Tensor]:
+        codes = self.encode(inputs)
+        return self.decode(codes), codes
+
+    def steer(self, activations: Tensor, *, feature: int, coefficient: float | Tensor) -> Tensor:
+        """Add one decoded feature direction to a residual activation."""
+        if feature < 0 or feature >= self.dictionary_features:
+            raise ValueError(f"feature must be in [0, {self.dictionary_features})")
+        coefficient_tensor = torch.as_tensor(coefficient, device=activations.device, dtype=activations.dtype)
+        return activations + coefficient_tensor[..., None] * self.decoder_directions[feature].to(activations)
+
+
+def sparse_metrics(
+    inputs: Tensor,
+    reconstruction: Tensor,
+    codes: Tensor,
+    *,
+    downstream_score_recovery: float | None = None,
+) -> SparseMetrics:
+    """Measure reconstruction quality, sparsity, and dictionary utilization."""
+    residual = inputs.float() - reconstruction.float()
+    mse = residual.square().mean()
+    variance = (inputs.float() - inputs.float().mean(dim=0, keepdim=True)).square().mean()
+    explained_variance = 1 - mse / variance.clamp_min(torch.finfo(variance.dtype).eps)
+    l0 = (codes != 0).sum(dim=-1).float().mean()
+    dead_count = int((codes != 0).flatten(0, -2).any(dim=0).logical_not().sum().item())
+    return SparseMetrics(
+        reconstruction_mse=float(mse.item()),
+        explained_variance=float(explained_variance.item()),
+        l0=float(l0.item()),
+        dead_feature_rate=dead_count / codes.shape[-1],
+        downstream_score_recovery=downstream_score_recovery,
+    )
+
+
+def score_recovery(original: Tensor, reconstructed: Tensor, ablated: Tensor) -> Tensor:
+    """Fraction of the original score effect recovered by reconstructed activations."""
+    denominator = original - ablated
+    epsilon = torch.finfo(denominator.dtype).eps
+    safe_denominator = torch.where(denominator.abs() < epsilon, torch.full_like(denominator, epsilon), denominator)
+    return (reconstructed - ablated) / safe_denominator
+
+
+def _autoencoder_inputs(autoencoder: TopKSparseAutoencoder, values: Tensor) -> Tensor:
+    return values.to(device=autoencoder.decoder.device, dtype=torch.float32)
+
+
+def reconstruct_trace_site(
+    autoencoder: TopKSparseAutoencoder,
+    trace: ViTTrace,
+    *,
+    site: InterventionSite,
+    layer: int,
+) -> Tensor:
+    """Reconstruct valid visual tokens while leaving prefixes and padding unchanged."""
+    values = _site_tensor(trace, site, layer)
+    prefix_length = trace.layout.prefix_length
+    validity = trace.layout.sequence_validity
+
+    def reconstruct_valid(visual: Tensor) -> Tensor:
+        reconstructed = visual.clone()
+        if validity.any():
+            valid_reconstruction, _ = autoencoder(_autoencoder_inputs(autoencoder, visual[validity]))
+            reconstructed[validity] = valid_reconstruction.to(visual)
+        return reconstructed
+
+    if site == "head_output":
+        sequence = values.permute(0, 2, 1, 3).flatten(2)
+        visual = sequence[:, prefix_length:]
+        sequence = torch.cat((sequence[:, :prefix_length], reconstruct_valid(visual)), dim=1)
+        return sequence.view(values.shape[0], values.shape[2], values.shape[1], values.shape[3]).permute(0, 2, 1, 3)
+    visual = values[:, prefix_length:]
+    return torch.cat((values[:, :prefix_length], reconstruct_valid(visual)), dim=1)
+
+
+def train_sparse_autoencoder(
+    autoencoder: TopKSparseAutoencoder,
+    activations: Iterable[Tensor],
+    *,
+    steps: int,
+    learning_rate: float = 1e-3,
+) -> list[float]:
+    """Train on streamed activation batches without retaining the activation dataset."""
+    if steps <= 0:
+        raise ValueError("steps must be positive")
+    optimizer = torch.optim.Adam(autoencoder.parameters(), lr=learning_rate)
+    losses: list[float] = []
+    iterator = iter(activations)
+    for _ in range(steps):
+        try:
+            batch = next(iterator)
+        except StopIteration:
+            iterator = iter(activations)
+            try:
+                batch = next(iterator)
+            except StopIteration:
+                raise ValueError("activation stream is empty") from None
+        batch = _autoencoder_inputs(autoencoder, batch).reshape(-1, autoencoder.input_features)
+        reconstruction, _ = autoencoder(batch)
+        loss = F.mse_loss(reconstruction, batch)
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+        autoencoder.normalize_decoder_()
+        losses.append(float(loss.detach().item()))
+    return losses
+
+
+@dataclass(frozen=True)
+class ViTActivationStream:
+    explainer: Any
+    dataloader: Iterable[Any]
+    site: InterventionSite
+    layer: int
+    forward_args: ForwardArgs
+
+    def __iter__(self) -> Iterator[Tensor]:
+        offset = 0
+        for batch in self.dataloader:
+            with preserve_explainer_state(self.explainer), torch.no_grad():
+                inputs, _ = _unpack_batch(batch, offset)
+                trace = trace_vit(self.explainer.model, inputs, TraceConfig(), self.forward_args)
+                values = _site_tensor(trace, self.site, self.layer)
+                if self.site == "head_output":
+                    values = values.permute(0, 2, 1, 3).flatten(2)
+                visual_values = values[:, trace.layout.prefix_length :]
+                values = visual_values[trace.layout.sequence_validity].float().detach()
+                offset += inputs.shape[0]
+            yield values
+
+
+def stream_vit_activations(
+    explainer,
+    dataloader: Iterable[Any],
+    *,
+    site: InterventionSite,
+    layer: int,
+    forward_args: ForwardArgs | None = None,
+) -> ViTActivationStream:
+    """Create a restartable float32 stream over visual-token activations."""
+    return ViTActivationStream(explainer, dataloader, site, layer, forward_args or ForwardArgs())
+
+
+def scan_sparse_features(
+    autoencoder: TopKSparseAutoencoder,
+    explainer,
+    dataloader: Iterable[Any],
+    *,
+    site: InterventionSite,
+    layer: int,
+    top_k: int = 10,
+    forward_args: ForwardArgs | None = None,
+) -> SparseFeatureAtlas:
+    """Retain top activating patch coordinates for every learned sparse feature."""
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    arguments = forward_args or ForwardArgs()
+    heaps: dict[int, list[tuple[float, int, ActivationRecord]]] = {}
+    counter = itertools.count()
+    offset = 0
+    layout: TokenLayout | None = None
+    with preserve_explainer_state(explainer), torch.no_grad():
+        for batch in dataloader:
+            inputs, sample_ids = _unpack_batch(batch, offset)
+            trace = trace_vit(explainer.model, inputs, TraceConfig(), arguments)
+            if layout is None:
+                layout = trace.layout
+            elif not trace.layout.spatially_matches(layout):
+                raise ValueError("sparse feature atlas batches must share one token layout")
+            values = _site_tensor(trace, site, layer)
+            if site == "head_output":
+                values = values.permute(0, 2, 1, 3).flatten(2)
+            values = values[:, trace.layout.prefix_length :]
+            codes = autoencoder.encode(_autoencoder_inputs(autoencoder, values))
+            for batch_index, sample_id in enumerate(sample_ids):
+                for token_index in range(codes.shape[1]):
+                    flat_patch = int(trace.layout.visual_indices[batch_index, token_index].item())
+                    if flat_patch < 0:
+                        continue
+                    coordinate = divmod(flat_patch, trace.layout.grid_size[1])
+                    for feature, value in enumerate(codes[batch_index, token_index].tolist()):
+                        record = ActivationRecord(sample_id, float(value), coordinate)
+                        heap = heaps.setdefault(feature, [])
+                        item = (record.value, next(counter), record)
+                        if len(heap) < top_k:
+                            heapq.heappush(heap, item)
+                        elif item[0] > heap[0][0]:
+                            heapq.heapreplace(heap, item)
+            offset += inputs.shape[0]
+    features = {
+        feature: tuple(item[2] for item in sorted(heap, key=lambda item: item[0], reverse=True))
+        for feature, heap in heaps.items()
+    }
+    return SparseFeatureAtlas(top_k, features, layout)

--- a/vit/explain/explainer.py
+++ b/vit/explain/explainer.py
@@ -1,0 +1,187 @@
+"""High-level ViT explanation orchestration."""
+
+from collections.abc import Callable, Sequence
+
+import torch.nn as nn
+from torch import Tensor
+
+from vit.head import AttentivePoolHead, Head, TransposedConv2dHead, UpsampleHead
+from vit.vit import ViT, ViTFeatures
+
+from .evaluation import EvaluationMetric, evaluate as run_evaluation
+from .interventions import (
+    intervene as run_interventions,
+    scan_activations as run_activation_scan,
+    sweep_interventions as run_intervention_sweep,
+)
+from .methods import AttributionMethod
+from .trace import preserve_explainer_state, trace_vit
+from .types import (
+    ActivationAtlas,
+    EvaluationReport,
+    Explanation,
+    ForwardArgs,
+    Intervention,
+    InterventionResult,
+    InterventionSite,
+    Target,
+    TraceConfig,
+    ViTTrace,
+)
+
+
+class ViTExplainer:
+    """Explain a native :class:`vit.ViT` using an explicit downstream output function."""
+
+    def __init__(
+        self,
+        model: ViT,
+        output_fn: Callable[[ViTFeatures], Tensor],
+        *,
+        output_modules: nn.Module | Sequence[nn.Module] = (),
+    ):
+        self.model = model
+        self.output_fn = output_fn
+        configured_modules = (output_modules,) if isinstance(output_modules, nn.Module) else tuple(output_modules)
+        modules = ((output_fn,) if isinstance(output_fn, nn.Module) else ()) + configured_modules
+        if not all(isinstance(module, nn.Module) for module in modules):
+            raise TypeError("output_modules must contain torch.nn.Module instances")
+        self.output_modules = tuple(dict.fromkeys(modules))
+
+    @classmethod
+    def from_head(
+        cls,
+        model: ViT,
+        head: str,
+        *,
+        pool: Callable[[ViTFeatures], Tensor] | None = None,
+    ) -> "ViTExplainer":
+        """Adapt a configured model head without guessing plain-head pooling semantics."""
+        head_module = model.get_head(head)
+        output_modules: tuple[nn.Module, ...] = ()
+        if isinstance(head_module, AttentivePoolHead):
+
+            def output_fn(features: ViTFeatures) -> Tensor:
+                return head_module(features.visual_tokens)
+
+        elif isinstance(head_module, (TransposedConv2dHead, UpsampleHead)):
+
+            def output_fn(features: ViTFeatures) -> Tensor:
+                return head_module(features.visual_tokens_as_grid.permute(0, 3, 1, 2))
+
+        elif isinstance(head_module, Head):
+            if pool is None:
+                raise ValueError("plain Head explainers require an explicit pool callable")
+            if isinstance(pool, nn.Module):
+                output_modules = (pool,)
+
+            def output_fn(features: ViTFeatures) -> Tensor:
+                return head_module(pool(features))
+
+        else:  # pragma: no cover - ViT.get_head currently narrows this union
+            raise TypeError(f"unsupported head type: {type(head_module).__name__}")
+        return cls(model, output_fn, output_modules=output_modules)
+
+    def attribute(
+        self,
+        inputs: Tensor,
+        *,
+        target: Target | None = None,
+        method: AttributionMethod,
+        forward_args: ForwardArgs | None = None,
+    ) -> Explanation:
+        """Attribute a selected scalar output with a native or extension method."""
+        return method.attribute(self, inputs, target, forward_args or ForwardArgs())
+
+    def trace(
+        self,
+        inputs: Tensor,
+        *,
+        config: TraceConfig | None = None,
+        forward_args: ForwardArgs | None = None,
+    ) -> ViTTrace:
+        """Capture a graph-connected eager trace and restore caller-owned model state."""
+        with preserve_explainer_state(self):
+            return trace_vit(self.model, inputs, config or TraceConfig(), forward_args or ForwardArgs())
+
+    def intervene(
+        self,
+        inputs: Tensor,
+        *,
+        target: Target | None,
+        interventions: list[Intervention] | tuple[Intervention, ...],
+        reference_inputs: Tensor | None = None,
+        forward_args: ForwardArgs | None = None,
+        reference_forward_args: ForwardArgs | None = None,
+    ) -> InterventionResult:
+        """Measure target-score changes from simultaneous causal interventions."""
+        return run_interventions(
+            self,
+            inputs,
+            target,
+            interventions,
+            forward_args or ForwardArgs(),
+            reference_inputs,
+            reference_forward_args,
+        )
+
+    def sweep(
+        self,
+        inputs: Tensor,
+        *,
+        target: Target | None,
+        interventions: list[Intervention] | tuple[Intervention, ...],
+        reference_inputs: Tensor | None = None,
+        forward_args: ForwardArgs | None = None,
+        reference_forward_args: ForwardArgs | None = None,
+    ) -> tuple[InterventionResult, ...]:
+        """Evaluate interventions independently in a reproducible causal-effect sweep."""
+        return run_intervention_sweep(
+            self,
+            inputs,
+            target,
+            interventions,
+            forward_args or ForwardArgs(),
+            reference_inputs,
+            reference_forward_args,
+        )
+
+    def scan_activations(
+        self,
+        dataloader,
+        *,
+        site: InterventionSite,
+        layer: int,
+        top_k: int = 10,
+        forward_args: ForwardArgs | None = None,
+        thumbnail=None,
+    ) -> ActivationAtlas:
+        """Find dataset-level top activating patches without retaining source images."""
+        return run_activation_scan(
+            self,
+            dataloader,
+            site=site,
+            layer=layer,
+            top_k=top_k,
+            forward_args=forward_args or ForwardArgs(),
+            thumbnail=thumbnail,
+        )
+
+    def evaluate(
+        self,
+        inputs: Tensor,
+        explanation: Explanation,
+        *,
+        target: Target | None = None,
+        metrics: list[EvaluationMetric] | tuple[EvaluationMetric, ...],
+        forward_args: ForwardArgs | None = None,
+    ) -> EvaluationReport:
+        """Evaluate an explanation with explicitly selected validation metrics."""
+        return run_evaluation(
+            self,
+            inputs,
+            explanation,
+            target,
+            metrics,
+            forward_args or ForwardArgs(),
+        )

--- a/vit/explain/interventions.py
+++ b/vit/explain/interventions.py
@@ -1,0 +1,318 @@
+"""Causal activation interventions and dataset-level activation scans."""
+
+import heapq
+import itertools
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from .trace import preserve_explainer_state, trace_vit
+from .types import (
+    ActivationAtlas,
+    ActivationRecord,
+    ForwardArgs,
+    Intervention,
+    InterventionResult,
+    InterventionSite,
+    Target,
+    TokenLayout,
+    TraceConfig,
+    ViTTrace,
+    select_targets,
+)
+
+
+def _layouts_match(first: TokenLayout, second: TokenLayout) -> bool:
+    return first.matches(second)
+
+
+def _site_tensor(trace: ViTTrace, site: InterventionSite, layer: int) -> Tensor:
+    captured = trace.layers[layer]
+    return {
+        "residual_pre": captured.residual_pre,
+        "head_output": captured.head_outputs,
+        "post_attention": captured.residual_post_attention,
+        "mlp_output": captured.mlp_output,
+        "residual_post": captured.residual_post,
+    }[site]
+
+
+def _selector(value: Sequence[int] | slice | None) -> Sequence[int] | slice:
+    return slice(None) if value is None else value
+
+
+def _selection_mask(size: int, selector: Sequence[int] | slice | None, device: torch.device) -> Tensor:
+    mask = torch.zeros(size, dtype=torch.bool, device=device)
+    mask[_selector(selector)] = True
+    return mask
+
+
+def _replacement(current: Tensor, intervention: Intervention, reference: Tensor | None) -> Tensor:
+    if intervention.mode == "zero":
+        return torch.zeros_like(current)
+    if intervention.mode == "reference":
+        if reference is None:
+            raise ValueError("reference intervention requires reference_inputs")
+        return reference.to(device=current.device, dtype=current.dtype)
+    if intervention.value is None:
+        raise ValueError(f"{intervention.mode} intervention requires value")
+    value = torch.as_tensor(intervention.value, device=current.device, dtype=current.dtype)
+    if intervention.mode == "mean" and value.ndim == 1:
+        expand = [1] * current.ndim
+        expand[-1] = value.shape[0]
+        value = value.view(expand)
+    return value.expand_as(current) if value.numel() != current.numel() else value.reshape_as(current)
+
+
+def apply_intervention(current: Tensor, intervention: Intervention, reference: Tensor | None = None) -> Tensor:
+    """Apply selectors without silently broadcasting an incompatible reference."""
+    if reference is not None and reference.shape != current.shape:
+        raise ValueError(f"reference activation shape {tuple(reference.shape)} does not match {tuple(current.shape)}")
+    replacement = _replacement(current, intervention, reference)
+    if intervention.tokens is None and intervention.channels is None and intervention.heads is None:
+        return replacement
+    token_mask = _selection_mask(current.shape[-2], intervention.tokens, current.device)
+    channel_mask = _selection_mask(current.shape[-1], intervention.channels, current.device)
+    if intervention.site == "head_output":
+        head_mask = _selection_mask(current.shape[1], intervention.heads, current.device)
+        selected = head_mask[None, :, None, None] & token_mask[None, None, :, None]
+        selected = selected & channel_mask[None, None, None, :]
+    else:
+        if intervention.heads is not None:
+            raise ValueError("head selectors are only valid at the head_output site")
+        selected = token_mask[None, :, None] & channel_mask[None, None, :]
+    return torch.where(selected, replacement, current)
+
+
+def intervene(
+    explainer,
+    inputs: Tensor,
+    target: Target | None,
+    interventions: Sequence[Intervention],
+    forward_args: ForwardArgs,
+    reference_inputs: Tensor | None,
+    reference_forward_args: ForwardArgs | None,
+) -> InterventionResult:
+    """Run simultaneous interventions and measure their selected-score effects."""
+    requested = tuple(interventions)
+    if not requested:
+        raise ValueError("at least one intervention is required")
+    with preserve_explainer_state(explainer), torch.no_grad():
+        baseline = trace_vit(explainer.model, inputs, TraceConfig(), forward_args)
+        baseline_scores = select_targets(explainer.output_fn(baseline.features), target)
+        reference = None
+        if any(item.mode == "reference" for item in requested):
+            if reference_inputs is None:
+                raise ValueError("reference intervention requires reference_inputs")
+            reference = trace_vit(
+                explainer.model,
+                reference_inputs,
+                TraceConfig(),
+                reference_forward_args or forward_args,
+            )
+            if not _layouts_match(baseline.layout, reference.layout):
+                raise ValueError("reference patching requires matching token layouts")
+
+        by_site = {(item.site, item.layer): [] for item in requested}
+        for item in requested:
+            if item.layer < 0 or item.layer >= explainer.model.config.depth:
+                raise ValueError(f"intervention layer must be in [0, {explainer.model.config.depth})")
+            by_site[(item.site, item.layer)].append(item)
+
+        def intervention_fn(site: str, layer: int, current: Tensor) -> Tensor:
+            output = current
+            for item in by_site.get((site, layer), ()):
+                reference_value = None if reference is None else _site_tensor(reference, item.site, layer)
+                output = apply_intervention(output, item, reference_value)
+            return output
+
+        changed = trace_vit(explainer.model, inputs, TraceConfig(), forward_args, intervention_fn)
+        changed_scores = select_targets(explainer.output_fn(changed.features), target)
+    absolute = changed_scores - baseline_scores
+    denominator = baseline_scores.abs().clamp_min(torch.finfo(baseline_scores.dtype).eps)
+    return InterventionResult(
+        baseline_scores=baseline_scores.detach(),
+        intervened_scores=changed_scores.detach(),
+        absolute_change=absolute.detach(),
+        relative_change=(absolute / denominator).detach(),
+        interventions=requested,
+    )
+
+
+def _repeat_forward_args(forward_args: ForwardArgs, repeats: int) -> ForwardArgs:
+    def repeat_batch(tensor: Tensor | None) -> Tensor | None:
+        return None if tensor is None else torch.cat([tensor] * repeats, dim=0)
+
+    return ForwardArgs(
+        mask=repeat_batch(forward_args.mask),
+        rope_seed=forward_args.rope_seed,
+        output_norm=forward_args.output_norm,
+        conditioning=repeat_batch(forward_args.conditioning),
+    )
+
+
+def _repeat_target(target: Target | None, repeats: int) -> Target | None:
+    if isinstance(target, Tensor) and target.ndim > 0:
+        return torch.cat([target] * repeats, dim=0)
+    return target
+
+
+def sweep_interventions(
+    explainer,
+    inputs: Tensor,
+    target: Target | None,
+    interventions: Sequence[Intervention],
+    forward_args: ForwardArgs,
+    reference_inputs: Tensor | None,
+    reference_forward_args: ForwardArgs | None,
+) -> tuple[InterventionResult, ...]:
+    """Evaluate independent interventions with one shared baseline and one batched changed forward."""
+    requested = tuple(interventions)
+    if not requested:
+        return ()
+    for item in requested:
+        if item.layer < 0 or item.layer >= explainer.model.config.depth:
+            raise ValueError(f"intervention layer must be in [0, {explainer.model.config.depth})")
+
+    with preserve_explainer_state(explainer), torch.no_grad():
+        baseline = trace_vit(explainer.model, inputs, TraceConfig(), forward_args)
+        baseline_scores = select_targets(explainer.output_fn(baseline.features), target)
+        reference = None
+        if any(item.mode == "reference" for item in requested):
+            if reference_inputs is None:
+                raise ValueError("reference intervention requires reference_inputs")
+            reference = trace_vit(
+                explainer.model,
+                reference_inputs,
+                TraceConfig(),
+                reference_forward_args or forward_args,
+            )
+            if not _layouts_match(baseline.layout, reference.layout):
+                raise ValueError("reference patching requires matching token layouts")
+
+        batch_size = inputs.shape[0]
+
+        def intervention_fn(site: str, layer: int, current: Tensor) -> Tensor:
+            chunks = current.split(batch_size, dim=0)
+            changed_chunks: list[Tensor] = []
+            changed = False
+            for item, chunk in zip(requested, chunks, strict=True):
+                if (item.site, item.layer) != (site, layer):
+                    changed_chunks.append(chunk)
+                    continue
+                reference_value = None if reference is None else _site_tensor(reference, item.site, layer)
+                changed_chunks.append(apply_intervention(chunk, item, reference_value))
+                changed = True
+            return torch.cat(changed_chunks, dim=0) if changed else current
+
+        batched_inputs = torch.cat([inputs] * len(requested), dim=0)
+        changed = trace_vit(
+            explainer.model,
+            batched_inputs,
+            TraceConfig(),
+            _repeat_forward_args(forward_args, len(requested)),
+            intervention_fn,
+        )
+        changed_scores = select_targets(
+            explainer.output_fn(changed.features),
+            _repeat_target(target, len(requested)),
+        ).view(len(requested), batch_size)
+
+    denominator = baseline_scores.abs().clamp_min(torch.finfo(baseline_scores.dtype).eps)
+    return tuple(
+        InterventionResult(
+            baseline_scores=baseline_scores.detach(),
+            intervened_scores=item_scores.detach(),
+            absolute_change=(item_scores - baseline_scores).detach(),
+            relative_change=((item_scores - baseline_scores) / denominator).detach(),
+            interventions=(item,),
+        )
+        for item, item_scores in zip(requested, changed_scores, strict=True)
+    )
+
+
+def _unpack_batch(batch: Any, offset: int) -> tuple[Tensor, list[str]]:
+    if isinstance(batch, Tensor):
+        return batch, [str(offset + index) for index in range(batch.shape[0])]
+    if isinstance(batch, Mapping):
+        inputs = batch.get("inputs")
+        ids = batch.get("sample_ids", batch.get("ids"))
+    elif isinstance(batch, (tuple, list)) and len(batch) >= 2:
+        inputs, ids = batch[0], batch[1]
+    else:
+        raise ValueError("dataloader batches must be tensors, (inputs, sample_ids), or mappings")
+    if not isinstance(inputs, Tensor):
+        raise ValueError("dataloader batch inputs must be a Tensor")
+    if ids is None:
+        ids = [str(offset + index) for index in range(inputs.shape[0])]
+    resolved_ids = [str(value) for value in ids]
+    if len(resolved_ids) != inputs.shape[0]:
+        raise ValueError("sample ID count must match batch size")
+    return inputs, resolved_ids
+
+
+def scan_activations(
+    explainer,
+    dataloader: Iterable[Any],
+    *,
+    site: InterventionSite,
+    layer: int,
+    top_k: int,
+    forward_args: ForwardArgs,
+    thumbnail: Callable[[Tensor, tuple[int, int]], Any] | None,
+) -> ActivationAtlas:
+    """Stream dataset batches and retain only top-k records per activation channel."""
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    heaps: dict[int, list[tuple[float, int, ActivationRecord]]] = {}
+    counter = itertools.count()
+    offset = 0
+    atlas_layout: TokenLayout | None = None
+    with preserve_explainer_state(explainer), torch.no_grad():
+        for batch in dataloader:
+            inputs, sample_ids = _unpack_batch(batch, offset)
+            trace = trace_vit(explainer.model, inputs, TraceConfig(), forward_args)
+            if atlas_layout is None:
+                atlas_layout = trace.layout
+            elif not trace.layout.spatially_matches(atlas_layout):
+                raise ValueError("activation atlas batches must share one token layout")
+            values = _site_tensor(trace, site, layer)
+            if site == "head_output":
+                values = values.permute(0, 2, 1, 3).flatten(2)[:, trace.layout.prefix_length :]
+            else:
+                values = values[:, trace.layout.prefix_length :]
+            for batch_index, sample_id in enumerate(sample_ids):
+                for token_index in range(values.shape[1]):
+                    flat_patch = int(trace.layout.visual_indices[batch_index, token_index].item())
+                    if flat_patch < 0:
+                        continue
+                    coordinate = divmod(flat_patch, trace.layout.grid_size[1])
+                    candidates: list[tuple[int, float, list[tuple[float, int, ActivationRecord]]]] = []
+                    for channel, value in enumerate(values[batch_index, token_index].tolist()):
+                        numeric_value = float(value)
+                        heap = heaps.setdefault(channel, [])
+                        if len(heap) < top_k or numeric_value > heap[0][0]:
+                            candidates.append((channel, numeric_value, heap))
+                    if not candidates:
+                        continue
+                    patch_thumbnail = None if thumbnail is None else thumbnail(inputs[batch_index], coordinate)
+                    for _channel, value, heap in candidates:
+                        record = ActivationRecord(
+                            sample_id=sample_id,
+                            value=value,
+                            patch_coordinate=coordinate,
+                            thumbnail=patch_thumbnail,
+                        )
+                        item = (record.value, next(counter), record)
+                        if len(heap) < top_k:
+                            heapq.heappush(heap, item)
+                        elif item[0] > heap[0][0]:
+                            heapq.heapreplace(heap, item)
+            offset += inputs.shape[0]
+    channels = {
+        channel: tuple(item[2] for item in sorted(heap, key=lambda item: item[0], reverse=True))
+        for channel, heap in heaps.items()
+    }
+    return ActivationAtlas(site=site, layer=layer, top_k=top_k, channels=channels, layout=atlas_layout)

--- a/vit/explain/methods.py
+++ b/vit/explain/methods.py
@@ -1,0 +1,421 @@
+"""Native and Captum-backed attribution methods for ViTs."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+import torch
+from torch import Tensor
+
+from vit.vit import ViTFeatures
+
+from .trace import make_token_layout, preserve_explainer_state, trace_vit
+from .types import Explanation, ForwardArgs, Target, TraceConfig, select_targets, tensor_configuration
+
+
+if TYPE_CHECKING:
+    from .explainer import ViTExplainer
+
+
+Query = int | Sequence[int] | Tensor | None
+
+
+class AttributionMethod(Protocol):
+    """Extension protocol implemented by all attribution methods."""
+
+    @property
+    def name(self) -> str: ...
+
+    def attribute(
+        self,
+        explainer: "ViTExplainer",
+        inputs: Tensor,
+        target: Target | None,
+        forward_args: ForwardArgs,
+    ) -> Explanation: ...
+
+
+def _queries(values: Tensor, query: Query) -> Tensor:
+    if query is None:
+        raise ValueError("attention explanations require an explicit query selector")
+    if isinstance(query, int):
+        return values[..., query, :]
+    indices = torch.as_tensor(query, device=values.device, dtype=torch.long)
+    selected = values.index_select(-2, indices)
+    return selected.mean(dim=-2)
+
+
+def _query_configuration(query: Query) -> int | list[int]:
+    if query is None:  # pragma: no cover - callers validate query first
+        raise ValueError("attention explanations require an explicit query selector")
+    if isinstance(query, int):
+        return query
+    if isinstance(query, Tensor):
+        value = query.detach().cpu()
+        return int(value.item()) if value.ndim == 0 else [int(index) for index in value.tolist()]
+    return [int(index) for index in query]
+
+
+def _visual_attribution(values: Tensor, trace, *, fill_value: float = float("nan")) -> Tensor:
+    visual = values[..., trace.layout.prefix_length :]
+    return trace.layout.scatter_visual(visual, fill_value=fill_value).flatten(1)
+
+
+def _scores(explainer: "ViTExplainer", features: ViTFeatures, target: Target | None) -> Tensor:
+    return select_targets(explainer.output_fn(features), target)
+
+
+def _result(
+    method: str,
+    attribution: Tensor,
+    scores: Tensor,
+    trace,
+    *,
+    layer_attributions: tuple[Tensor, ...] = (),
+    configuration: dict[str, Any] | None = None,
+) -> Explanation:
+    return Explanation(
+        method=method,
+        token_attributions=attribution.detach(),
+        pixel_attributions=None,
+        target_scores=scores.detach(),
+        layout=trace.layout,
+        layer_attributions=tuple(value.detach() for value in layer_attributions),
+        configuration=configuration or {},
+    )
+
+
+def compose_rollout(attention_layers: Sequence[Tensor]) -> Tensor:
+    """Average heads, add residual identity, row-normalize, and compose layers."""
+    if not attention_layers:
+        raise ValueError("attention rollout requires at least one layer")
+    rollout: Tensor | None = None
+    for attention in attention_layers:
+        if attention.ndim != 4 or attention.shape[-1] != attention.shape[-2]:
+            raise ValueError("attention layers must have shape (batch, heads, query, key) with square maps")
+        fused = attention.mean(dim=1)
+        identity = torch.eye(fused.shape[-1], device=fused.device, dtype=fused.dtype)
+        fused = fused + identity
+        fused = fused / fused.sum(dim=-1, keepdim=True).clamp_min(torch.finfo(fused.dtype).eps)
+        rollout = fused if rollout is None else fused @ rollout
+    assert rollout is not None
+    return rollout
+
+
+@dataclass(frozen=True)
+class RawAttention:
+    """Per-head attention from one layer for an explicit query selector."""
+
+    query: Query = None
+    layer: int = -1
+    head: int | None = None
+    name: str = "raw_attention"
+
+    def attribute(self, explainer, inputs, target, forward_args) -> Explanation:
+        if self.query is None:
+            raise ValueError("raw attention requires an explicit query selector")
+        layer = self.layer % explainer.model.config.depth
+        with preserve_explainer_state(explainer):
+            trace = trace_vit(explainer.model, inputs, TraceConfig(layers=(layer,)), forward_args)
+            probabilities = trace.layers[0].attention_probabilities
+            fused = probabilities.mean(1) if self.head is None else probabilities[:, self.head]
+            attribution = _visual_attribution(_queries(fused, self.query), trace)
+            scores = _scores(explainer, trace.features, target)
+        return _result(
+            self.name,
+            attribution,
+            scores,
+            trace,
+            configuration={"query": _query_configuration(self.query), "layer": layer, "head": self.head},
+        )
+
+
+@dataclass(frozen=True)
+class AttentionRollout:
+    """Target-independent attention-flow rollout for an explicit query."""
+
+    query: Query = None
+    layers: tuple[int, ...] | None = None
+    name: str = "attention_rollout"
+
+    def attribute(self, explainer, inputs, target, forward_args) -> Explanation:
+        if self.query is None:
+            raise ValueError("attention rollout requires an explicit query selector")
+        with preserve_explainer_state(explainer):
+            trace = trace_vit(explainer.model, inputs, TraceConfig(layers=self.layers), forward_args)
+            rollout = compose_rollout(tuple(layer.attention_probabilities for layer in trace.layers))
+            attribution = _visual_attribution(_queries(rollout, self.query), trace)
+            scores = _scores(explainer, trace.features, target)
+        return _result(
+            self.name,
+            attribution,
+            scores,
+            trace,
+            configuration={"query": _query_configuration(self.query), "layers": self.layers},
+        )
+
+
+@dataclass(frozen=True)
+class GradientAttentionRollout:
+    """Class-specific rollout using positive gradient-times-attention relevance."""
+
+    query: Query = None
+    layers: tuple[int, ...] | None = None
+    name: str = "gradient_attention_rollout"
+
+    def attribute(self, explainer, inputs, target, forward_args) -> Explanation:
+        if self.query is None:
+            raise ValueError("gradient attention rollout requires an explicit query selector")
+        with preserve_explainer_state(explainer):
+            trace = trace_vit(explainer.model, inputs, TraceConfig(layers=self.layers), forward_args)
+            scores = _scores(explainer, trace.features, target)
+            probabilities = tuple(layer.attention_probabilities for layer in trace.layers)
+            gradients = torch.autograd.grad(scores.sum(), probabilities, retain_graph=False)
+            relevance = tuple(
+                (gradient * probability).clamp_min(0) for gradient, probability in zip(gradients, probabilities)
+            )
+            rollout = compose_rollout(relevance)
+            attribution = _visual_attribution(_queries(rollout, self.query), trace)
+        return _result(
+            self.name,
+            attribution,
+            scores,
+            trace,
+            configuration={"query": _query_configuration(self.query), "layers": self.layers},
+        )
+
+
+@dataclass(frozen=True)
+class LeGrad:
+    """ViT feature-formation attribution from positive attention gradients."""
+
+    layers: tuple[int, ...] | None = None
+    name: str = "legrad"
+
+    def attribute(self, explainer, inputs, target, forward_args) -> Explanation:
+        with preserve_explainer_state(explainer):
+            trace = trace_vit(explainer.model, inputs, TraceConfig(layers=self.layers), forward_args)
+            final_scores = _scores(explainer, trace.features, target)
+            layer_values: list[Tensor] = []
+            for layer in trace.layers:
+                intermediate = (
+                    explainer.model.output_norm(layer.residual_post)
+                    if forward_args.output_norm
+                    else layer.residual_post
+                )
+                features = ViTFeatures(
+                    intermediate,
+                    explainer.model.config.num_register_tokens,
+                    explainer.model.config.num_cls_tokens,
+                    trace.layout.grid_size,
+                )
+                intermediate_scores = _scores(explainer, features, target)
+                gradient = torch.autograd.grad(
+                    intermediate_scores.sum(),
+                    layer.attention_probabilities,
+                    retain_graph=True,
+                )[0]
+                relevance = gradient.clamp_min(0).mean(dim=(1, 2))
+                layer_values.append(_visual_attribution(relevance, trace))
+            attribution = torch.stack(layer_values).mean(0)
+        return _result(
+            self.name,
+            attribution,
+            final_scores,
+            trace,
+            layer_attributions=tuple(layer_values),
+            configuration={"layers": self.layers},
+        )
+
+
+@dataclass(frozen=True)
+class LayerGradCAM:
+    """Grad-CAM over one block's post-block visual-token grid."""
+
+    layer: int = -1
+    relu: bool = True
+    name: str = "layer_grad_cam"
+
+    def attribute(self, explainer, inputs, target, forward_args) -> Explanation:
+        layer = self.layer % explainer.model.config.depth
+        with preserve_explainer_state(explainer):
+            trace = trace_vit(explainer.model, inputs, TraceConfig(), forward_args)
+            scores = _scores(explainer, trace.features, target)
+            residual_post = trace.layers[layer].residual_post
+            gradients = torch.autograd.grad(scores.sum(), residual_post, retain_graph=False)[0]
+            activations = residual_post[:, trace.layout.prefix_length :]
+            gradients = gradients[:, trace.layout.prefix_length :]
+            channel_weights = gradients.mean(dim=1, keepdim=True)
+            relevance = (activations * channel_weights).sum(dim=-1)
+            if self.relu:
+                relevance = relevance.clamp_min(0)
+            attribution = trace.layout.scatter_visual(relevance).flatten(1)
+        return _result(self.name, attribution, scores, trace, configuration={"layer": layer, "relu": self.relu})
+
+
+def _captum() -> Any:
+    try:
+        import captum.attr
+    except ModuleNotFoundError as error:
+        if error.name == "captum" or (error.name and error.name.startswith("captum.")):
+            raise ModuleNotFoundError(
+                "Captum attribution methods require the explainability extra: pip install 'vit[explainability]'",
+                name="captum",
+            ) from None
+        raise
+    return captum.attr
+
+
+def _input_to_tokens(attributions: Tensor, layout) -> Tensor:
+    height, width = layout.modeled_size
+    patch_height, patch_width = layout.patch_size
+    cropped = attributions[..., :height, :width]
+    patches = cropped.unfold(2, patch_height, patch_height).unfold(3, patch_width, patch_width)
+    return patches.sum(dim=(1, -1, -2)).flatten(1)
+
+
+class _CaptumMethod:
+    name = "captum"
+
+    def _attribute(
+        self,
+        captum_attr: Any,
+        forward,
+        inputs: Tensor,
+        explainer: "ViTExplainer",
+        additional_forward_args: tuple[Any, ...],
+    ) -> Tensor:
+        raise NotImplementedError
+
+    def attribute(self, explainer, inputs, target, forward_args) -> Explanation:
+        captum_attr = _captum()
+        with preserve_explainer_state(explainer):
+            layout = make_token_layout(explainer.model, inputs, forward_args.mask)
+
+            def forward(
+                tensor: Tensor,
+                mask: Tensor | None,
+                conditioning: Tensor | None,
+                selected_target: Target | None,
+            ) -> Tensor:
+                features = explainer.model(
+                    tensor,
+                    mask=mask,
+                    rope_seed=forward_args.rope_seed,
+                    output_norm=forward_args.output_norm,
+                    conditioning=conditioning,
+                )
+                return _scores(explainer, features, selected_target)
+
+            additional_forward_args = (forward_args.mask, forward_args.conditioning, target)
+            pixel_attributions = self._attribute(
+                captum_attr,
+                forward,
+                inputs,
+                explainer,
+                additional_forward_args,
+            )
+            scores = forward(inputs, *additional_forward_args)
+            token_attributions = _input_to_tokens(pixel_attributions, layout)
+            token_attributions = token_attributions.masked_fill(~layout.visual_validity, torch.nan)
+        return Explanation(
+            method=self.name,
+            token_attributions=token_attributions.detach(),
+            pixel_attributions=pixel_attributions.detach(),
+            target_scores=scores.detach(),
+            layout=layout,
+            configuration=tensor_configuration(**self.__dict__),
+        )
+
+
+@dataclass(frozen=True)
+class Saliency(_CaptumMethod):
+    absolute: bool = False
+    name: str = "saliency"
+
+    def _attribute(self, captum_attr, forward, inputs, explainer, additional_forward_args):
+        _ = explainer
+        return captum_attr.Saliency(forward).attribute(
+            inputs,
+            abs=self.absolute,
+            additional_forward_args=additional_forward_args,
+        )
+
+
+@dataclass(frozen=True)
+class InputXGradient(_CaptumMethod):
+    name: str = "input_x_gradient"
+
+    def _attribute(self, captum_attr, forward, inputs, explainer, additional_forward_args):
+        _ = explainer
+        return captum_attr.InputXGradient(forward).attribute(
+            inputs,
+            additional_forward_args=additional_forward_args,
+        )
+
+
+@dataclass(frozen=True)
+class IntegratedGradients(_CaptumMethod):
+    baseline: Tensor | float = 0.0
+    n_steps: int = 50
+    method: str = "gausslegendre"
+    name: str = "integrated_gradients"
+
+    def _attribute(self, captum_attr, forward, inputs, explainer, additional_forward_args):
+        _ = explainer
+        return captum_attr.IntegratedGradients(forward).attribute(
+            inputs,
+            baselines=self.baseline,
+            n_steps=self.n_steps,
+            method=self.method,
+            additional_forward_args=additional_forward_args,
+        )
+
+
+@dataclass(frozen=True)
+class SmoothGrad(_CaptumMethod):
+    samples: int = 25
+    stdev: float = 0.1
+    absolute: bool = False
+    seed: int = 0
+    name: str = "smoothgrad"
+
+    def _attribute(self, captum_attr, forward, inputs, explainer, additional_forward_args):
+        _ = explainer
+        saliency = captum_attr.Saliency(forward)
+        devices = [inputs.device] if inputs.device.type == "cuda" else []
+        with torch.random.fork_rng(devices=devices):
+            if inputs.device.type == "cuda":
+                with torch.cuda.device(inputs.device):
+                    torch.cuda.manual_seed(self.seed)
+            else:
+                generator = torch.Generator(device="cpu").manual_seed(self.seed)
+                torch.random.set_rng_state(generator.get_state())
+            return captum_attr.NoiseTunnel(saliency).attribute(
+                inputs,
+                nt_type="smoothgrad",
+                nt_samples=self.samples,
+                stdevs=self.stdev,
+                abs=self.absolute,
+                additional_forward_args=additional_forward_args,
+            )
+
+
+@dataclass(frozen=True)
+class PatchOcclusion(_CaptumMethod):
+    baseline: Tensor | float = 0.0
+    patch_size: tuple[int, int] | None = None
+    strides: tuple[int, int] | None = None
+    name: str = "patch_occlusion"
+
+    def _attribute(self, captum_attr, forward, inputs, explainer, additional_forward_args):
+        configured_patch_size = tuple(explainer.model.config.patch_size)
+        patch_size = self.patch_size or (int(configured_patch_size[0]), int(configured_patch_size[1]))
+        strides = self.strides or patch_size
+        return captum_attr.Occlusion(forward).attribute(
+            inputs,
+            baselines=self.baseline,
+            sliding_window_shapes=(inputs.shape[1], *patch_size),
+            strides=(inputs.shape[1], *strides),
+            additional_forward_args=additional_forward_args,
+        )

--- a/vit/explain/trace.py
+++ b/vit/explain/trace.py
@@ -1,0 +1,203 @@
+"""Graph-connected eager tracing for native two-dimensional ViTs."""
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Protocol
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from vit.attention import _permute_and_fold_head, project_qkv_packed
+from vit.norm import get_norm_bias
+from vit.patch_embed import PatchEmbed2d
+from vit.tokens import apply_mask
+from vit.transformer import _forward_mlp
+from vit.vit import ViT, ViTFeatures
+
+from .types import ForwardArgs, LayerTrace, TokenLayout, TraceConfig, ViTTrace
+
+
+class _StatefulExplainer(Protocol):
+    model: ViT
+    output_modules: tuple[nn.Module, ...]
+
+
+@contextmanager
+def preserve_model_state(*models: nn.Module) -> Iterator[None]:
+    """Run explanation code in eval mode without changing caller-owned module state."""
+    training_states = {module: module.training for model in models for module in model.modules()}
+    parameter_states = {
+        parameter: (parameter.requires_grad, None if parameter.grad is None else parameter.grad.detach().clone())
+        for model in models
+        for parameter in model.parameters()
+    }
+    for model in models:
+        model.eval()
+    try:
+        yield
+    finally:
+        for module, training in training_states.items():
+            module.training = training
+        for parameter, (requires_grad, gradient) in parameter_states.items():
+            parameter.requires_grad_(requires_grad)
+            parameter.grad = gradient
+
+
+@contextmanager
+def preserve_explainer_state(explainer: _StatefulExplainer) -> Iterator[None]:
+    """Preserve the backbone and any external modules used by ``output_fn``."""
+    with preserve_model_state(explainer.model, *explainer.output_modules):
+        yield
+
+
+def _visual_indices(mask: Tensor | None, batch_size: int, token_count: int, device: torch.device) -> Tensor:
+    indices = torch.arange(token_count, device=device).view(1, token_count, 1).expand(batch_size, -1, -1)
+    if mask is None:
+        return indices.squeeze(-1)
+    return apply_mask(mask, indices, padding_value=-1).squeeze(-1)
+
+
+def make_token_layout(model: ViT, inputs: Tensor, mask: Tensor | None) -> TokenLayout:
+    """Describe prefix, masked, padded, and ignored-border token semantics."""
+    if inputs.ndim != 4 or len(model.config.patch_size) != 2:
+        raise ValueError("vit.explain supports 2D ViT inputs with shape (batch, channels, height, width)")
+    if not isinstance(model.stem, PatchEmbed2d):
+        raise ValueError("vit.explain supports 2D ViT inputs with shape (batch, channels, height, width)")
+    grid_size = model.stem.tokenized_size(inputs.shape[2:])
+    token_count = grid_size[0] * grid_size[1]
+    if mask is not None:
+        if mask.dtype != torch.bool or mask.shape != (inputs.shape[0], token_count):
+            raise ValueError(f"mask must be bool with shape {(inputs.shape[0], token_count)}, got {tuple(mask.shape)}")
+        mask = mask.to(device=inputs.device)
+        validity = mask
+    else:
+        validity = torch.ones((inputs.shape[0], token_count), dtype=torch.bool, device=inputs.device)
+    patch_size = tuple(model.config.patch_size)
+    return TokenLayout(
+        grid_size=grid_size,
+        patch_size=(int(patch_size[0]), int(patch_size[1])),
+        original_size=(int(inputs.shape[-2]), int(inputs.shape[-1])),
+        modeled_size=model.stem.original_size(grid_size),
+        num_cls_tokens=model.config.num_cls_tokens,
+        num_register_tokens=model.config.num_register_tokens,
+        visual_indices=_visual_indices(mask, inputs.shape[0], token_count, inputs.device),
+        visual_validity=validity,
+    )
+
+
+def attention_output_from_heads(attention, head_outputs: Tensor) -> Tensor:
+    """Project per-head values back into the residual stream."""
+    output = F.linear(_permute_and_fold_head(head_outputs), attention.out_proj.weight, attention.out_proj.bias)
+    return attention.dropout(output)
+
+
+def eager_self_attention(attention, x: Tensor, rope: Tensor | None) -> tuple[Tensor, Tensor, Tensor]:
+    """Compute attention output from explicitly materialized probabilities."""
+    q_norm_weight = attention.q_norm.weight if attention.q_norm is not None else None
+    q_norm_bias = get_norm_bias(attention.q_norm) if attention.q_norm is not None else None
+    k_norm_weight = attention.k_norm.weight if attention.k_norm is not None else None
+    k_norm_bias = get_norm_bias(attention.k_norm) if attention.k_norm is not None else None
+    qk_eps = attention.q_norm.eps or 1e-5 if attention.q_norm is not None else 1e-5
+    q, k, value = project_qkv_packed(
+        x,
+        attention.qkv_proj.weight,
+        attention.qkv_proj.bias,
+        attention.norm.weight,
+        get_norm_bias(attention.norm),
+        attention._use_layer_norm,
+        attention._head_dim,
+        attention.norm.eps or 1e-5,
+        q_norm_weight,
+        q_norm_bias,
+        k_norm_weight,
+        k_norm_bias,
+        attention._use_layer_norm,
+        qk_eps,
+        attention._qk_normalization,
+        rope,
+    )
+    probabilities = (q @ k.mT * (attention._head_dim**-0.5)).softmax(dim=-1)
+    if not probabilities.requires_grad:
+        probabilities.requires_grad_()
+    head_outputs = probabilities @ value
+    return attention_output_from_heads(attention, head_outputs), probabilities, head_outputs
+
+
+def trace_vit(
+    model: ViT,
+    inputs: Tensor,
+    config: TraceConfig,
+    forward_args: ForwardArgs,
+    intervention: Callable[[str, int, Tensor], Tensor] | None = None,
+) -> ViTTrace:
+    """Execute the model through its eager, inspectable transformer path."""
+    layout = make_token_layout(model, inputs, forward_args.mask)
+    model._validate_conditioning(forward_args.conditioning)
+    tokenized_size = layout.grid_size
+    x = model.normalize_patch_embeddings(model.stem(inputs))
+    if forward_args.mask is not None:
+        x = apply_mask(forward_args.mask.to(inputs.device), x)
+    x = model.add_prefix_tokens(x)
+    rope = (
+        model.prepare_rope(tokenized_size, forward_args.mask, forward_args.rope_seed)
+        if model.rope is not None
+        else None
+    )
+    selected_layers = set(range(model.config.depth) if config.layers is None else config.layers)
+    if any(layer < 0 or layer >= model.config.depth for layer in selected_layers):
+        raise ValueError(f"trace layers must be in [0, {model.config.depth})")
+
+    layers: list[LayerTrace] = []
+    for layer_index in range(model.config.depth):
+        block = model.get_block(layer_index)
+        residual_pre = intervention("residual_pre", layer_index, x) if intervention is not None else x
+        x = residual_pre
+        attention_output, probabilities, head_outputs = eager_self_attention(block.self_attention, x, rope)
+        if intervention is not None:
+            head_outputs = intervention("head_output", layer_index, head_outputs)
+            attention_output = attention_output_from_heads(block.self_attention, head_outputs)
+        residual_post_attention = x + block.layer_scale_attn(attention_output)
+        if intervention is not None:
+            residual_post_attention = intervention("post_attention", layer_index, residual_post_attention)
+        mlp_output = _forward_mlp(
+            block.mlp,
+            residual_post_attention,
+            forward_args.conditioning,
+            None,
+            inputs.shape[0],
+        )
+        if intervention is not None:
+            mlp_output = intervention("mlp_output", layer_index, mlp_output)
+        x = residual_post_attention + block.layer_scale_mlp(mlp_output)
+        if intervention is not None:
+            x = intervention("residual_post", layer_index, x)
+        if layer_index in selected_layers:
+            layer_trace = LayerTrace(
+                layer=layer_index,
+                residual_pre=residual_pre,
+                attention_probabilities=probabilities,
+                head_outputs=head_outputs,
+                attention_output=attention_output,
+                residual_post_attention=residual_post_attention,
+                mlp_output=mlp_output,
+                residual_post=x,
+            )
+            if config.retain_gradients:
+                for tensor in (
+                    layer_trace.residual_pre,
+                    layer_trace.attention_probabilities,
+                    layer_trace.head_outputs,
+                    layer_trace.attention_output,
+                    layer_trace.residual_post_attention,
+                    layer_trace.mlp_output,
+                    layer_trace.residual_post,
+                ):
+                    if tensor.requires_grad:
+                        tensor.retain_grad()
+            layers.append(layer_trace)
+    if forward_args.output_norm:
+        x = model.output_norm(x)
+    features = ViTFeatures(x, model.config.num_register_tokens, model.config.num_cls_tokens, tokenized_size)
+    return ViTTrace(features=features, layout=layout, layers=tuple(layers), forward_args=forward_args)

--- a/vit/explain/types.py
+++ b/vit/explain/types.py
@@ -1,0 +1,237 @@
+"""Typed public data structures for ViT explainability."""
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, TypeAlias
+
+import torch
+from torch import Tensor
+
+from vit.vit import ViTFeatures
+
+
+TargetCallable: TypeAlias = Callable[[Tensor], Tensor]
+DenseTarget: TypeAlias = tuple[int, ...]
+Target: TypeAlias = int | Tensor | DenseTarget | TargetCallable
+
+
+@dataclass(frozen=True)
+class ForwardArgs:
+    """Arguments that must be reproduced for every explanatory forward pass."""
+
+    mask: Tensor | None = None
+    rope_seed: int | None = None
+    output_norm: bool = True
+    conditioning: Tensor | None = None
+
+
+@dataclass(frozen=True)
+class TraceConfig:
+    """Control which trace tensors retain gradients and which layers are returned."""
+
+    layers: tuple[int, ...] | None = None
+    retain_gradients: bool = False
+
+
+@dataclass(frozen=True)
+class TokenLayout:
+    """Map model sequence positions to the original two-dimensional patch grid."""
+
+    grid_size: tuple[int, int]
+    patch_size: tuple[int, int]
+    original_size: tuple[int, int]
+    modeled_size: tuple[int, int]
+    num_cls_tokens: int
+    num_register_tokens: int
+    visual_indices: Tensor
+    visual_validity: Tensor
+
+    @property
+    def prefix_length(self) -> int:
+        return self.num_cls_tokens + self.num_register_tokens
+
+    @property
+    def sequence_validity(self) -> Tensor:
+        return self.visual_indices >= 0
+
+    @property
+    def visual_token_count(self) -> int:
+        return self.grid_size[0] * self.grid_size[1]
+
+    def spatially_matches(self, other: "TokenLayout") -> bool:
+        """Return whether two layouts describe the same modeled image geometry."""
+        return (
+            self.grid_size == other.grid_size
+            and self.patch_size == other.patch_size
+            and self.original_size == other.original_size
+            and self.modeled_size == other.modeled_size
+        )
+
+    def matches(self, other: "TokenLayout") -> bool:
+        """Return whether two layouts have identical token and spatial semantics."""
+        return (
+            self.spatially_matches(other)
+            and self.num_cls_tokens == other.num_cls_tokens
+            and self.num_register_tokens == other.num_register_tokens
+            and torch.equal(self.visual_indices, other.visual_indices)
+            and torch.equal(self.visual_validity, other.visual_validity)
+        )
+
+    def scatter_visual(self, values: Tensor, *, fill_value: float = float("nan")) -> Tensor:
+        """Scatter a final visual-sequence axis back to the complete patch grid."""
+        if values.shape[0] != self.visual_indices.shape[0]:
+            raise ValueError("attribution batch size does not match token layout")
+        if values.shape[-1] != self.visual_indices.shape[-1]:
+            raise ValueError("attribution token count does not match token layout")
+        output = values.new_full((*values.shape[:-1], self.visual_token_count), fill_value)
+        for batch_index in range(values.shape[0]):
+            valid = self.sequence_validity[batch_index]
+            indices = self.visual_indices[batch_index, valid]
+            output[batch_index, ..., indices] = values[batch_index, ..., valid]
+        return output.view(*values.shape[:-1], *self.grid_size)
+
+
+@dataclass(frozen=True)
+class LayerTrace:
+    """Captured tensors at one transformer encoder block."""
+
+    layer: int
+    residual_pre: Tensor
+    attention_probabilities: Tensor
+    head_outputs: Tensor
+    attention_output: Tensor
+    residual_post_attention: Tensor
+    mlp_output: Tensor
+    residual_post: Tensor
+
+
+@dataclass(frozen=True)
+class ViTTrace:
+    """Eager forward result with graph-connected internal transformer tensors."""
+
+    features: ViTFeatures
+    layout: TokenLayout
+    layers: tuple[LayerTrace, ...]
+    forward_args: ForwardArgs
+
+
+@dataclass(frozen=True)
+class Explanation:
+    """Raw, unnormalized attribution values and the layout needed to render them."""
+
+    method: str
+    token_attributions: Tensor
+    pixel_attributions: Tensor | None
+    target_scores: Tensor
+    layout: TokenLayout
+    layer_attributions: tuple[Tensor, ...] = ()
+    configuration: Mapping[str, Any] = field(default_factory=dict)
+
+
+InterventionSite: TypeAlias = Literal[
+    "residual_pre",
+    "head_output",
+    "post_attention",
+    "mlp_output",
+    "residual_post",
+]
+
+
+@dataclass(frozen=True)
+class Intervention:
+    """Replace selected activations at a causal intervention site."""
+
+    site: InterventionSite
+    layer: int
+    mode: Literal["zero", "constant", "mean", "reference"] = "zero"
+    tokens: Sequence[int] | slice | None = None
+    channels: Sequence[int] | slice | None = None
+    heads: Sequence[int] | slice | None = None
+    value: float | Tensor | None = None
+
+
+@dataclass(frozen=True)
+class InterventionResult:
+    """Target-score changes caused by one or more interventions."""
+
+    baseline_scores: Tensor
+    intervened_scores: Tensor
+    absolute_change: Tensor
+    relative_change: Tensor
+    interventions: tuple[Intervention, ...]
+
+
+@dataclass(frozen=True)
+class ActivationRecord:
+    sample_id: str
+    value: float
+    patch_coordinate: tuple[int, int]
+    thumbnail: Any | None = None
+
+
+@dataclass(frozen=True)
+class ActivationAtlas:
+    """Top activating dataset patches for channels at one trace site."""
+
+    site: InterventionSite
+    layer: int
+    top_k: int
+    channels: Mapping[int, tuple[ActivationRecord, ...]]
+    layout: TokenLayout | None = None
+
+
+@dataclass(frozen=True)
+class MetricResult:
+    name: str
+    values: Tensor
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    """Faithfulness, robustness, and localization measurements."""
+
+    metrics: Mapping[str, MetricResult]
+
+
+def select_targets(outputs: Tensor, target: Target | None) -> Tensor:
+    """Select exactly one scalar output per batch item."""
+    if callable(target):
+        selected = target(outputs)
+    elif target is None:
+        if outputs.ndim != 1:
+            raise ValueError("target is required when output_fn does not return one scalar per example")
+        selected = outputs
+    elif isinstance(target, int):
+        selected = outputs[:, target]
+    elif isinstance(target, tuple):
+        selected = outputs[(slice(None), *target)]
+    elif isinstance(target, Tensor):
+        if target.ndim == 0:
+            selected = outputs[:, int(target.item())]
+        elif target.ndim == 1 and outputs.ndim == 2 and target.shape[0] == outputs.shape[0]:
+            selected = outputs.gather(1, target.to(device=outputs.device, dtype=torch.long)[:, None]).squeeze(1)
+        elif target.ndim == 2 and target.shape[0] == outputs.shape[0]:
+            batch = torch.arange(outputs.shape[0], device=outputs.device)
+            selected = outputs[(batch, *target.to(device=outputs.device, dtype=torch.long).unbind(1))]
+        else:
+            raise ValueError("target tensor must contain one class index or coordinate per example")
+    else:
+        raise TypeError(f"unsupported target type: {type(target).__name__}")
+    if selected.shape != (outputs.shape[0],):
+        raise ValueError(f"target must select one scalar per example, got shape {tuple(selected.shape)}")
+    return selected
+
+
+def tensor_configuration(**values: Any) -> dict[str, Any]:
+    """Serialize method configuration without retaining tensor payloads."""
+    return {
+        name: {
+            "kind": "tensor",
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+        }
+        if isinstance(value, torch.Tensor)
+        else value
+        for name, value in values.items()
+    }

--- a/vit/explain/visualization.py
+++ b/vit/explain/visualization.py
@@ -1,0 +1,88 @@
+"""Explicit normalization and interpolation operations for attribution maps."""
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from .types import Explanation
+
+
+Normalization = Literal["none", "minmax", "symmetric", "absolute"]
+
+
+def normalize_attribution(values: Tensor, mode: Normalization = "minmax") -> Tensor:
+    """Normalize a map only when the caller explicitly requests it."""
+    if mode == "none":
+        return values
+    finite = torch.isfinite(values)
+    safe = values.where(finite, 0)
+    dimensions = tuple(range(1, values.ndim))
+    has_finite = finite.any(dim=dimensions, keepdim=True)
+    if mode == "absolute":
+        safe = safe.abs()
+        denominator = safe.amax(dim=dimensions, keepdim=True).clamp_min(torch.finfo(safe.dtype).eps)
+        result = safe / denominator
+    elif mode == "symmetric":
+        denominator = safe.abs().amax(dim=dimensions, keepdim=True).clamp_min(torch.finfo(safe.dtype).eps)
+        result = safe / denominator
+    elif mode == "minmax":
+        minimum = values.masked_fill(~finite, torch.inf).amin(dim=dimensions, keepdim=True)
+        maximum = values.masked_fill(~finite, -torch.inf).amax(dim=dimensions, keepdim=True)
+        minimum = minimum.where(has_finite, 0)
+        maximum = maximum.where(has_finite, 0)
+        result = (safe - minimum) / (maximum - minimum).clamp_min(torch.finfo(safe.dtype).eps)
+    else:
+        raise ValueError(f"unknown attribution normalization: {mode}")
+    return result.where(finite, torch.nan)
+
+
+def interpolate_token_attribution(
+    explanation: Explanation,
+    *,
+    size: tuple[int, int] | None = None,
+    normalization: Normalization = "none",
+) -> Tensor:
+    """Interpolate token scores while leaving unmodeled image borders as NaN."""
+    target_size = size or explanation.layout.original_size
+    if any(dimension <= 0 for dimension in target_size):
+        raise ValueError("attribution interpolation dimensions must be positive")
+    if size is not None and target_size == explanation.layout.modeled_size:
+        modeled_target_size = target_size
+    else:
+        modeled_target_size = tuple(
+            max(1, target * modeled // original)
+            for target, modeled, original in zip(
+                target_size,
+                explanation.layout.modeled_size,
+                explanation.layout.original_size,
+                strict=True,
+            )
+        )
+    values = explanation.token_attributions.view(-1, 1, *explanation.layout.grid_size)
+    values = normalize_attribution(values, normalization)
+    layout_validity = explanation.layout.visual_validity.to(device=values.device).view_as(values)
+    validity = torch.isfinite(values) & layout_validity
+    safe_values = values.where(validity, 0)
+    support = validity.to(values.dtype)
+    weighted_values = F.interpolate(
+        safe_values,
+        size=modeled_target_size,
+        mode="bilinear",
+        align_corners=False,
+    )
+    interpolated_support = F.interpolate(
+        support,
+        size=modeled_target_size,
+        mode="bilinear",
+        align_corners=False,
+    )
+    modeled = weighted_values / interpolated_support.clamp_min(torch.finfo(values.dtype).eps)
+    modeled_validity = F.interpolate(support, size=modeled_target_size, mode="nearest").bool()
+    modeled = modeled.where(modeled_validity, torch.nan)
+    if target_size == modeled_target_size:
+        return modeled[:, 0]
+    result = modeled.new_full((modeled.shape[0], 1, *target_size), torch.nan)
+    result[..., : modeled_target_size[0], : modeled_target_size[1]] = modeled
+    return result[:, 0]

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -517,7 +518,7 @@ class ViT(nn.Module):
 
     @property
     def prefix_length(self) -> int:
-        return self.config.num_register_tokens
+        return self.config.num_cls_tokens + self.config.num_register_tokens
 
     @torch.compile(fullgraph=True)
     def add_prefix_tokens(self, x: Tensor) -> Tensor:
@@ -605,28 +606,46 @@ class ViT(nn.Module):
             return self.forward(x, mask, rope_seed, output_norm, conditioning)
 
     @torch.no_grad()
-    def _reshape_attention_weights(self, w: Tensor, tokenized_size: Sequence[int]) -> Tensor:
+    def _reshape_attention_weights(
+        self, w: Tensor, tokenized_size: Sequence[int], mask: Tensor | None = None
+    ) -> Tensor:
         B, H, Lq, Lk = w.shape
         assert Lq == Lk, f"Query and key lengths must match, got {Lq} and {Lk}"
-        w = w[..., self.config.num_register_tokens :].view(B, H, Lq, *tokenized_size)
+        w = w[..., self.prefix_length :]
+        if mask is not None:
+            full = w.new_zeros((B, H, Lq, math.prod(tokenized_size)))
+            for batch_index in range(B):
+                key_count = int(mask[batch_index].sum().item())
+                full[batch_index, ..., mask[batch_index]] = w[batch_index, ..., :key_count]
+            w = full
+        w = w.view(B, H, Lq, *tokenized_size)
         return w.contiguous()
 
-    def forward_attention_weights(self, x: Tensor, conditioning: Tensor | None = None) -> dict[str, Tensor]:
+    def forward_attention_weights(
+        self,
+        x: Tensor,
+        conditioning: Tensor | None = None,
+        *,
+        mask: Tensor | None = None,
+        rope_seed: int | None = None,
+    ) -> dict[str, Tensor]:
         self._validate_conditioning(conditioning)
 
         # Prepare transformer input
         tokenized_size = self.stem.tokenized_size(x.shape[2:])
         x = self.stem(x)
         x = self.normalize_patch_embeddings(x)
+        x = apply_mask(mask, x) if mask is not None else x
         x = self.add_prefix_tokens(x)
+        rope = self.prepare_rope(tokenized_size, mask, rope_seed) if self.rope is not None else None
 
         # Apply transformer
         weights: dict[str, Tensor] = {}
         for i, block in enumerate(self.blocks):
             assert isinstance(block, TransformerEncoderLayer)
-            w_i = block.self_attention.forward_weights(x)
-            weights[f"layer_{i}"] = self._reshape_attention_weights(w_i, tokenized_size)
-            x = block(x, conditioning=conditioning)
+            w_i = block.self_attention.forward_weights(x, rope=rope)
+            weights[f"layer_{i}"] = self._reshape_attention_weights(w_i, tokenized_size, mask)
+            x = block(x, rope=rope, conditioning=conditioning)
 
         return weights
 


### PR DESCRIPTION
## Motivation

The existing attention-weight output path exposes only a narrow view of transformer behavior. Native ViT users need class-specific attribution, causal interventions, dataset-level activation inspection, faithfulness evaluation, and safe artifact workflows that preserve this repository's masking, RoPE, prefix-token, conditioning, and non-divisible-image semantics. Users also need direct references for the algorithms and metrics they report in published work.

## Solution

Add a lazily imported `vit.explain` package centered on `ViTExplainer`, `TokenLayout`, and immutable result types. Explanations use an eager graph-connected trace only when capture is requested, while ordinary inference retains the fused path. Native transformer methods own token semantics, Captum supplies generic gradient and perturbation methods, and evaluation plus causal tools make explanation quality testable. The documentation maps every public method and metric to primary literature and distinguishes local adaptations from exact reproductions.

## Changes

- Add raw attention, attention rollout, gradient-weighted rollout, LeGrad, Layer Grad-CAM, saliency, input-times-gradient, Integrated Gradients, SmoothGrad, and patch occlusion.
- Add graph-connected tracing with correct CLS/register prefixes, masking, RoPE seeds, conditioning, output norms, ignored borders, and caller-state restoration.
- Add residual, head, attention, MLP, and post-block interventions; causal sweeps; activation atlases; and reference patching with layout validation.
- Add deletion/insertion, SaCo, infidelity, sensitivity, completeness, localization, and parameter-randomization evaluation.
- Add deterministic non-pickle NPZ/JSON artifacts and the artifact-only `vit-explain inspect|render|compare` CLI.
- Add the pinned `explainability` extra, executable examples, detailed documentation, benchmark tooling, and an isolated experimental Top-K sparse autoencoder.
- Add primary-source citation tables, adaptation notes, and copy-ready BibTeX for attribution, evaluation, intervention, and sparse-feature methods.
- Add broad correctness guidance discovered during iterative review.

### Quick start

```python
from vit.explain import LeGrad, ViTExplainer

explainer = ViTExplainer.from_head(model, "cls")
explanation = explainer.attribute(inputs, target=3, method=LeGrad())
```

## Test plan

- [x] BibTeX parsing for `docs/explainability-references.bib`
- [x] `make test-explain` (112 passed)
- [x] `make check` (858 passed, 5 skipped, 94% coverage; includes Ruff, BasedPyright, wheel validation, and full tests)
- [x] `make test-ci` (572 passed, 282 skipped, 9 deselected, 94% coverage)
- [x] Four-round structured review/fix loop ending in a clean review

## Test suite changes (Required)

No tests were removed.

- [x] `tests/test_vit.py::TestViT::test_forward_attention_weights_counts_cls_prefix_and_scatters_masked_keys` extends the existing attention-output contract to cover combined CLS/register prefixes, RoPE, and masked-key scattering.
- [x] `tests/test_distribution.py` extends distribution and optional-import checks to cover the explainability extra and `vit-explain` entry point.
- [x] New explainability test modules cover tracing, attribution formulas, interventions, evaluation, artifacts and CLI behavior, visualization, sparse features, CPU/CUDA device boundaries, and state restoration.

Generated with Codex