### PR TITLE
Add opt-in CUDA GLU GEMM autotuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,35 @@ features = model(x)
 logits = model.heads["cls"](features.visual_tokens)  # B, 10
 ```
 
+## CUDA GLU GEMM Autotuning
+
+Compiled GLU MLPs can opt into PyTorch Inductor GEMM autotuning when steady-state CUDA throughput is more important
+than compilation time:
+
+```python
+config = ViTConfig(
+    # ... other params ...
+    activation="swiglu",
+    glu_max_autotune_gemm=True,
+)
+```
+
+The option requires a GLU activation and is not supported with MLP quantization. It applies only to CUDA inputs when
+the MLP input width is at least 512. CPU inputs and smaller MLPs use the default compiled GLU path.
+
+On an RTX 3090 with PyTorch 2.13.0, native BF16, and `B=4, S=256, D=768, FFN=3072`, the opt-in changed the measured
+steady-state latency as follows:
+
+| Pass | Default | Autotuned | Change |
+|------|--------:|----------:|-------:|
+| Forward | 0.413 ms | 0.331 ms | 19.9% faster |
+| Backward | 0.853 ms | 0.752 ms | 11.9% faster |
+| Forward + backward | 1.157 ms | 1.016 ms | 12.2% faster |
+
+A fresh-cache forward-backward compile increased from 4.53 seconds to 21.40 seconds. Results vary by GPU, PyTorch
+version, shape, and dtype, so keep the option disabled unless steady-state measurements on the target workload justify
+the compile-time cost.
+
 ## Explainability
 
 `vit.explain` traces the native 2D `ViT`, attributes selected outputs, runs causal interventions, and evaluates

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -58,6 +58,41 @@ The component benchmark CLI supports:
 - `compare`
 - `list-baselines`
 - `--norm-type` to switch between `rmsnorm` and `layernorm` for `mlp` and `self_attention` runs
+- `--glu-max-autotune-gemm` to measure the opt-in CUDA Inductor GEMM autotuning path for GLU MLPs
+
+The autotuning setting is recorded in each result but omitted from `case_id`, so matching enabled and disabled cases
+compare directly. For example:
+
+```bash
+vit-component-benchmark run \
+    --save-as glu-default \
+    --components mlp \
+    --device cuda \
+    --activation swiglu \
+    --batch-sizes 4 \
+    --seq-lens 256 \
+    --hidden-sizes 768 \
+    --ffn-mults 4
+
+vit-component-benchmark run \
+    --save-as glu-autotuned \
+    --components mlp \
+    --device cuda \
+    --activation swiglu \
+    --batch-sizes 4 \
+    --seq-lens 256 \
+    --hidden-sizes 768 \
+    --ffn-mults 4 \
+    --glu-max-autotune-gemm
+
+vit-component-benchmark compare \
+    --baseline glu-default \
+    --candidate glu-autotuned
+```
+
+This option applies only to CUDA inputs with an MLP input width of at least 512. CPU inputs and smaller MLPs keep the
+default compiled path. Inductor evaluates more GEMM choices during the first compile, so use fresh cache directories
+when measuring compile latency and exclude compilation from steady-state measurements.
 
 Detailed workflows, recipes, and interpretation guidance are maintained in:
 - `.agents/skills/vit-component-benchmark/SKILL.md`

--- a/benchmark/component_benchmark.py
+++ b/benchmark/component_benchmark.py
@@ -88,6 +88,7 @@ class ComponentBenchmarkCase:
     num_heads: int
     ffn_hidden_size: int
     activation: str
+    glu_max_autotune_gemm: bool
     use_rope: bool
     hidden_dropout: float
     attention_dropout: float
@@ -260,6 +261,7 @@ def build_component_benchmark_cases(
     num_heads: list[int] | None = None,
     ffn_mults: list[int] | None = None,
     activation: str | None = None,
+    glu_max_autotune_gemm: bool = False,
     use_rope: bool | None = None,
     hidden_dropout: float | None = None,
     attention_dropout: float | None = None,
@@ -307,6 +309,7 @@ def build_component_benchmark_cases(
                 "seq_len": seq_len,
                 "hidden_size": hidden_size,
                 "activation": resolved_activation,
+                "glu_max_autotune_gemm": glu_max_autotune_gemm,
                 "hidden_dropout": resolved_hidden_dropout,
                 "attention_dropout": resolved_attention_dropout,
                 "train_mode": resolved_train_mode,
@@ -375,6 +378,7 @@ def run_component_benchmark_suite(
     num_heads: list[int] | None = None,
     ffn_mults: list[int] | None = None,
     activation: str | None = None,
+    glu_max_autotune_gemm: bool = False,
     use_rope: bool | None = None,
     hidden_dropout: float | None = None,
     attention_dropout: float | None = None,
@@ -402,6 +406,7 @@ def run_component_benchmark_suite(
         num_heads=num_heads,
         ffn_mults=ffn_mults,
         activation=activation,
+        glu_max_autotune_gemm=glu_max_autotune_gemm,
         use_rope=use_rope,
         hidden_dropout=hidden_dropout,
         attention_dropout=attention_dropout,
@@ -730,6 +735,7 @@ def _build_mlp_target(
         ffn_hidden_size=case.ffn_hidden_size,
         bias=case.bias,
         activation=case.activation,
+        glu_max_autotune_gemm=case.glu_max_autotune_gemm,
         norm_type=case.norm_type,
         eps=case.eps,
         dropout=case.hidden_dropout,

--- a/benchmark/component_cli.py
+++ b/benchmark/component_cli.py
@@ -72,6 +72,7 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--autocast-dtype", choices=AUTOCAST_CHOICES, default="none")
 
     run_parser.add_argument("--activation", type=str)
+    run_parser.add_argument("--glu-max-autotune-gemm", action=argparse.BooleanOptionalAction, default=False)
     run_parser.add_argument("--norm-type", choices=list(NORM_TYPE_CHOICES), default="rmsnorm")
     run_parser.add_argument("--use-rope", action=argparse.BooleanOptionalAction, default=None)
     run_parser.add_argument("--hidden-dropout", type=float)
@@ -166,6 +167,7 @@ def _run_command(args: argparse.Namespace) -> int:
         "num_heads": args.num_heads,
         "ffn_mults": args.ffn_mults,
         "activation": args.activation,
+        "glu_max_autotune_gemm": args.glu_max_autotune_gemm,
         "norm_type": args.norm_type,
         "use_rope": args.use_rope,
         "hidden_dropout": args.hidden_dropout,

--- a/tests/test_component_benchmark.py
+++ b/tests/test_component_benchmark.py
@@ -22,6 +22,24 @@ def test_build_component_benchmark_cases_default_grid() -> None:
     assert {case.component for case in cases} == {"mlp", "self_attention"}
     assert {case.pass_mode for case in cases} == {"forward"}
     assert {case.norm_type for case in cases} == {"rmsnorm"}
+    assert not any(case.glu_max_autotune_gemm for case in cases)
+
+
+def test_glu_max_autotune_gemm_is_recorded_without_changing_case_id() -> None:
+    common_kwargs = {
+        "components": ["mlp"],
+        "batch_sizes": [1],
+        "seq_lens": [8],
+        "hidden_sizes": [512],
+        "ffn_mults": [2],
+        "activation": "swiglu",
+    }
+    baseline = build_component_benchmark_cases(**common_kwargs)[0]
+    candidate = build_component_benchmark_cases(**common_kwargs, glu_max_autotune_gemm=True)[0]
+
+    assert baseline.glu_max_autotune_gemm is False
+    assert candidate.glu_max_autotune_gemm is True
+    assert candidate.case_id == baseline.case_id
 
 
 def test_run_component_benchmark_case_forward_mlp_cpu() -> None:
@@ -204,8 +222,11 @@ def test_component_cli_run_and_compare(tmp_path: Path) -> None:
 
     candidate_args = baseline_args.copy()
     candidate_args[candidate_args.index("baseline")] = "candidate"
-    candidate_args.extend(["--norm-type", "layernorm"])
+    candidate_args.extend(["--norm-type", "layernorm", "--glu-max-autotune-gemm"])
     assert component_benchmark_main(candidate_args) == 0
+
+    _, candidate_records = load_benchmark_run(tmp_path / "candidate")
+    assert candidate_records[0]["glu_max_autotune_gemm"] is True
 
     compare_args = [
         "compare",

--- a/tests/test_fused.py
+++ b/tests/test_fused.py
@@ -6,7 +6,13 @@ import torch.nn.functional as F
 from torch.testing import assert_close
 from torchao.quantization import Int8Tensor, Int8WeightOnlyConfig
 
-from vit.fused import VALID_ADALN_GATE_INITS, AdaNormMLP, NormLinear, NormMLP
+from vit.fused import (
+    MIN_GLU_AUTOTUNE_HIDDEN_SIZE,
+    VALID_ADALN_GATE_INITS,
+    AdaNormMLP,
+    NormLinear,
+    NormMLP,
+)
 
 
 TORCHAO_QUANTIZATION_CONFIG_VERSION = 2
@@ -99,6 +105,71 @@ class TestNormMLP:
         assert layer.fc2.bias is not None
         assert torch.count_nonzero(layer.fc1.bias) == 0
         assert torch.count_nonzero(layer.fc2.bias) == 0
+
+    def test_glu_max_autotune_gemm_requires_glu_activation(self):
+        with pytest.raises(ValueError, match="glu_max_autotune_gemm requires a GLU activation"):
+            NormMLP(10, 20, activation="srelu", glu_max_autotune_gemm=True)
+
+    def test_glu_max_autotune_gemm_rejects_quantization(self):
+        layer = NormMLP(10, 20, activation="swiglu", glu_max_autotune_gemm=True)
+
+        with pytest.raises(ValueError, match="glu_max_autotune_gemm is not supported with quantization"):
+            layer.apply_quantization(Int8WeightOnlyConfig(version=TORCHAO_QUANTIZATION_CONFIG_VERSION))
+
+    def test_glu_max_autotune_gemm_falls_back_on_cpu(self, mocker):
+        layer = NormMLP(
+            MIN_GLU_AUTOTUNE_HIDDEN_SIZE,
+            2 * MIN_GLU_AUTOTUNE_HIDDEN_SIZE,
+            activation="swiglu",
+            glu_max_autotune_gemm=True,
+        )
+        x = torch.randn(1, 2, MIN_GLU_AUTOTUNE_HIDDEN_SIZE)
+        default_output = torch.ones_like(x)
+        default_glu = mocker.patch("vit.fused.norm_mlp_glu", return_value=default_output)
+        autotuned_glu = mocker.patch("vit.fused.norm_mlp_glu_max_autotune_gemm")
+
+        output = layer(x)
+
+        assert output is default_output
+        default_glu.assert_called_once()
+        autotuned_glu.assert_not_called()
+
+    @pytest.mark.cuda
+    def test_glu_max_autotune_gemm_falls_back_below_hidden_threshold(self, mocker):
+        hidden_size = MIN_GLU_AUTOTUNE_HIDDEN_SIZE - 1
+        layer = NormMLP(hidden_size, 2 * hidden_size, activation="swiglu", glu_max_autotune_gemm=True)
+        x = torch.randn(1, 2, hidden_size, device="cuda")
+        default_output = torch.ones_like(x)
+        default_glu = mocker.patch("vit.fused.norm_mlp_glu", return_value=default_output)
+        autotuned_glu = mocker.patch("vit.fused.norm_mlp_glu_max_autotune_gemm")
+
+        output = layer(x)
+
+        assert output is default_output
+        default_glu.assert_called_once()
+        autotuned_glu.assert_not_called()
+
+    @pytest.mark.cuda
+    def test_glu_max_autotune_gemm_selects_cuda_path_at_hidden_threshold(self, mocker):
+        layer = NormMLP(
+            MIN_GLU_AUTOTUNE_HIDDEN_SIZE,
+            2 * MIN_GLU_AUTOTUNE_HIDDEN_SIZE,
+            activation="swiglu",
+            glu_max_autotune_gemm=True,
+        )
+        x = torch.randn(1, 2, MIN_GLU_AUTOTUNE_HIDDEN_SIZE, device="cuda")
+        autotuned_output = torch.ones_like(x)
+        default_glu = mocker.patch("vit.fused.norm_mlp_glu")
+        autotuned_glu = mocker.patch(
+            "vit.fused.norm_mlp_glu_max_autotune_gemm",
+            return_value=autotuned_output,
+        )
+
+        output = layer(x)
+
+        assert output is autotuned_output
+        default_glu.assert_not_called()
+        autotuned_glu.assert_called_once()
 
     @pytest.mark.parametrize("activation", ["relu", "swiglu", "srelu"])
     @pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
@@ -250,3 +321,61 @@ class TestAdaNormMLP:
             y_quant = quantized_layer(x, conditioning=conditioning)
         # TorchAO v2 accumulates directly quantized linear outputs in float32.
         assert_close(y.float(), y_quant.float(), atol=1e-2, rtol=0)
+
+
+@pytest.mark.compile
+@pytest.mark.cuda
+@pytest.mark.parametrize("conditioned", [False, True], ids=["norm_mlp", "ada_norm_mlp"])
+def test_glu_max_autotune_gemm_matches_default_cuda_forward_and_backward(conditioned):
+    torch.manual_seed(0)
+    hidden_size = MIN_GLU_AUTOTUNE_HIDDEN_SIZE
+    ffn_hidden_size = 2 * hidden_size
+    common_kwargs = {
+        "hidden_size": hidden_size,
+        "ffn_hidden_size": ffn_hidden_size,
+        "activation": "swiglu",
+        "dropout": 0.0,
+        "device": torch.device("cuda"),
+        "dtype": torch.bfloat16,
+    }
+    if conditioned:
+        baseline = AdaNormMLP(**common_kwargs, conditioning_size=hidden_size, adaln_gate_init=1.0)
+        candidate = AdaNormMLP(
+            **common_kwargs,
+            conditioning_size=hidden_size,
+            adaln_gate_init=1.0,
+            glu_max_autotune_gemm=True,
+        )
+    else:
+        baseline = NormMLP(**common_kwargs)
+        candidate = NormMLP(**common_kwargs, glu_max_autotune_gemm=True)
+    candidate.load_state_dict(baseline.state_dict())
+
+    baseline_input = torch.randn(2, 16, hidden_size, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    candidate_input = baseline_input.detach().clone().requires_grad_(True)
+    conditioning = torch.randn(2, hidden_size, device="cuda", dtype=torch.bfloat16) if conditioned else None
+
+    if conditioned:
+        assert isinstance(baseline, AdaNormMLP)
+        assert isinstance(candidate, AdaNormMLP)
+        baseline_output = baseline(baseline_input, conditioning=conditioning)
+        candidate_output = candidate(candidate_input, conditioning=conditioning)
+    else:
+        baseline_output = baseline(baseline_input)
+        candidate_output = candidate(candidate_input)
+
+    baseline_output.float().square().mean().backward()
+    candidate_output.float().square().mean().backward()
+
+    assert_close(candidate_output, baseline_output, rtol=1e-2, atol=1e-2)
+    assert baseline_input.grad is not None
+    assert candidate_input.grad is not None
+    assert_close(candidate_input.grad, baseline_input.grad, rtol=1e-2, atol=1e-2)
+    baseline_parameters = dict(baseline.named_parameters())
+    candidate_parameters = dict(candidate.named_parameters())
+    assert candidate_parameters.keys() == baseline_parameters.keys()
+    for name, baseline_parameter in baseline_parameters.items():
+        candidate_parameter = candidate_parameters[name]
+        assert baseline_parameter.grad is not None
+        assert candidate_parameter.grad is not None
+        assert_close(candidate_parameter.grad, baseline_parameter.grad, rtol=1e-2, atol=1e-2)

--- a/tests/test_vit.py
+++ b/tests/test_vit.py
@@ -88,6 +88,30 @@ class TestViT:
     def test_patch_embed_normalization_defaults_to_false(self, config):
         assert config.patch_embed_normalization is False
 
+    def test_glu_max_autotune_gemm_requires_glu_activation(self, config):
+        with pytest.raises(ValueError, match="glu_max_autotune_gemm requires a GLU activation"):
+            replace(config, glu_max_autotune_gemm=True)
+
+    def test_glu_max_autotune_gemm_yaml_roundtrip(self, config):
+        autotuned_config = replace(config, activation="swiglu", glu_max_autotune_gemm=True)
+
+        loaded_config = ViTConfig.from_yaml(autotuned_config.to_yaml())
+
+        assert loaded_config.glu_max_autotune_gemm is True
+
+    def test_glu_max_autotune_gemm_is_forwarded_to_all_layer_factories(self):
+        model = ViT(
+            make_factory_override_config(
+                activation="swiglu",
+                glu_max_autotune_gemm=True,
+            )
+        )
+
+        assert model.get_block(0).mlp.glu_max_autotune_gemm is True
+        for factory_name in FACTORY_METHOD_NAMES:
+            layer = getattr(model, factory_name)()
+            assert layer.mlp.glu_max_autotune_gemm is True
+
     def test_default_dtype_is_bfloat16(self):
         """Verify that the default master weight dtype is BF16."""
         config = ViTConfig(

--- a/vit/fused.py
+++ b/vit/fused.py
@@ -13,6 +13,7 @@ from .norm import NormType, apply_norm, get_norm_bias, is_layer_norm, make_norm,
 
 
 VALID_ADALN_GATE_INITS = (0.0, 1.0)
+MIN_GLU_AUTOTUNE_HIDDEN_SIZE = 512
 
 
 def validate_adaln_gate_init(adaln_gate_init: float) -> None:
@@ -200,6 +201,68 @@ def norm_mlp_glu(
     return x
 
 
+@torch.compile(
+    fullgraph=True,
+    dynamic=False,
+    options={
+        "layout_optimization": True,
+        "epilogue_fusion": True,
+        "aggressive_fusion": True,
+        "max_autotune_gemm": True,
+    },
+)
+def norm_mlp_glu_max_autotune_gemm(
+    # Keep this signature and body separate from norm_mlp_glu so each compiled path has its own Dynamo cache.
+    # fmt: off
+    x: Tensor,
+    fc1_weight: Tensor,
+    fc1_bias: Tensor | None,
+    fc2_weight: Tensor,
+    fc2_bias: Tensor | None,
+    norm_weight: Tensor | None,
+    norm_bias: Tensor | None,
+    use_layer_norm: bool,
+    activation: Callable[[Tensor], Tensor],
+    eps: float,
+    dropout: float,
+    training: bool,
+    limit: float | None = None,
+    extra_bias: float | None = None,
+    norm_scale_delta: Tensor | None = None,
+    norm_shift: Tensor | None = None,
+    output_gate: Tensor | None = None,
+    # fmt: on
+) -> Tensor:
+    if norm_weight is not None:
+        x = apply_norm(
+            x,
+            norm_weight,
+            norm_bias,
+            eps,
+            use_layer_norm=use_layer_norm,
+            scale_delta=norm_scale_delta,
+            shift=norm_shift,
+        )
+
+    # FC1 - GLU
+    x = F.linear(x, fc1_weight, fc1_bias)
+    x_linear, x_glu = x.chunk(2, dim=-1)
+    if limit is not None:
+        x_linear = x_linear.clamp(min=-limit, max=limit)
+        x_glu = x_glu.clamp(min=None, max=limit)
+    if extra_bias is not None:
+        x_linear = x_linear + extra_bias
+    x = activation(x_glu) * x_linear
+    x = F.dropout(x, p=dropout, training=training)
+
+    # FC2
+    x = F.linear(x, fc2_weight, fc2_bias)
+    x = F.dropout(x, p=dropout, training=training, inplace=True)
+    if output_gate is not None:
+        x = x * output_gate
+    return x
+
+
 class NormMLP(nn.Module):
     def __init__(
         self,
@@ -215,6 +278,7 @@ class NormMLP(nn.Module):
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
         norm_type: NormType = "rmsnorm",
+        glu_max_autotune_gemm: bool = False,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -226,11 +290,14 @@ class NormMLP(nn.Module):
         else:
             self._is_glu = False
             self.fc1 = nn.Linear(hidden_size, ffn_hidden_size, bias=bias, **factory_kwargs)
+        if glu_max_autotune_gemm and not self._is_glu:
+            raise ValueError("glu_max_autotune_gemm requires a GLU activation")
         self.fc2 = nn.Linear(ffn_hidden_size, hidden_size, bias=bias, **factory_kwargs)
         self.dropout = nn.Dropout(dropout)
         self.activation = get_activation(activation)
         self.limit = limit
         self.extra_bias = extra_bias
+        self.glu_max_autotune_gemm = glu_max_autotune_gemm
         self.quantization_config = quantization_config
         self.reset_parameters()
 
@@ -245,6 +312,8 @@ class NormMLP(nn.Module):
         """Apply quantization to both linear layers using torchao."""
         if quantization_config is None:
             return
+        if self.glu_max_autotune_gemm:
+            raise ValueError("glu_max_autotune_gemm is not supported with quantization")
         quantize_(self.fc1, quantization_config)
         quantize_(self.fc2, quantization_config)
 
@@ -257,7 +326,14 @@ class NormMLP(nn.Module):
         output_gate: Tensor | None = None,
     ) -> Tensor:
         if self._is_glu:
-            return norm_mlp_glu(
+            glu_forward = norm_mlp_glu
+            if (
+                self.glu_max_autotune_gemm
+                and x.device.type == "cuda"
+                and self.fc1.in_features >= MIN_GLU_AUTOTUNE_HIDDEN_SIZE
+            ):
+                glu_forward = norm_mlp_glu_max_autotune_gemm
+            return glu_forward(
                 # fmt: off
                 x,
                 self.fc1.weight,
@@ -329,6 +405,7 @@ class AdaNormMLP(NormMLP):
         norm_type: NormType = "rmsnorm",
         conditioning_size: int | None = None,
         adaln_gate_init: float = 0.0,
+        glu_max_autotune_gemm: bool = False,
     ):
         super().__init__(
             hidden_size=hidden_size,
@@ -343,6 +420,7 @@ class AdaNormMLP(NormMLP):
             device=device,
             dtype=dtype,
             norm_type=norm_type,
+            glu_max_autotune_gemm=glu_max_autotune_gemm,
         )
         validate_adaln_gate_init(adaln_gate_init)
         factory_kwargs = {"device": device, "dtype": dtype}

--- a/vit/transformer.py
+++ b/vit/transformer.py
@@ -91,6 +91,7 @@ def _make_mlp(
     quantization_config: Any | None,
     conditioning_size: int | None,
     adaln_gate_init: float,
+    glu_max_autotune_gemm: bool,
     device: torch.device | None,
     dtype: torch.dtype | None,
 ) -> NormMLP:
@@ -108,6 +109,7 @@ def _make_mlp(
             quantization_config=quantization_config,
             conditioning_size=conditioning_size,
             adaln_gate_init=adaln_gate_init,
+            glu_max_autotune_gemm=glu_max_autotune_gemm,
             device=device,
             dtype=dtype,
         )
@@ -122,6 +124,7 @@ def _make_mlp(
         limit=limit,
         extra_bias=extra_bias,
         quantization_config=quantization_config,
+        glu_max_autotune_gemm=glu_max_autotune_gemm,
         device=device,
         dtype=dtype,
     )
@@ -171,6 +174,7 @@ class TransformerEncoderLayer(nn.Module):
         qk_normalization: bool = False,
         conditioning_size: int | None = None,
         adaln_gate_init: float = 0.0,
+        glu_max_autotune_gemm: bool = False,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -201,6 +205,7 @@ class TransformerEncoderLayer(nn.Module):
             quantization_config=None,
             conditioning_size=conditioning_size,
             adaln_gate_init=adaln_gate_init,
+            glu_max_autotune_gemm=glu_max_autotune_gemm,
             device=device,
             dtype=dtype,
         )
@@ -273,6 +278,7 @@ class TransformerDecoderLayer(nn.Module):
         qk_normalization: bool = False,
         conditioning_size: int | None = None,
         adaln_gate_init: float = 0.0,
+        glu_max_autotune_gemm: bool = False,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -316,6 +322,7 @@ class TransformerDecoderLayer(nn.Module):
             quantization_config=None,
             conditioning_size=conditioning_size,
             adaln_gate_init=adaln_gate_init,
+            glu_max_autotune_gemm=glu_max_autotune_gemm,
             device=device,
             dtype=dtype,
         )
@@ -418,6 +425,7 @@ class CrossAttentionTransformer(nn.Module):
         qk_normalization: bool = False,
         conditioning_size: int | None = None,
         adaln_gate_init: float = 0.0,
+        glu_max_autotune_gemm: bool = False,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
@@ -448,6 +456,7 @@ class CrossAttentionTransformer(nn.Module):
             quantization_config=None,
             conditioning_size=conditioning_size,
             adaln_gate_init=adaln_gate_init,
+            glu_max_autotune_gemm=glu_max_autotune_gemm,
             device=device,
             dtype=dtype,
         )

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -100,6 +100,7 @@ class ViTConfig:
     layer_scale: float | None = None
     glu_limit: float | None = None
     glu_extra_bias: float | None = None
+    glu_max_autotune_gemm: bool = False
 
     # RoPE options
     rope_normalize_coords: Literal["min", "max", "separate"] = "separate"
@@ -139,6 +140,8 @@ class ViTConfig:
             raise ValueError(f"hidden_size ({self.hidden_size}) must be even when using Fourier positional encoding")
         if self.conditioning_size is not None and self.conditioning_size <= 0:
             raise ValueError(f"conditioning_size must be positive when provided, got {self.conditioning_size}")
+        if self.glu_max_autotune_gemm and not self.activation.endswith("glu"):
+            raise ValueError("glu_max_autotune_gemm requires a GLU activation")
         validate_adaln_gate_init(self.adaln_gate_init)
 
     def instantiate(self, device: torch.device | None = None) -> "ViT":
@@ -387,6 +390,7 @@ class ViT(nn.Module):
             dtype=resolved_dtype,
             conditioning_size=self.config.conditioning_size,
             adaln_gate_init=self.config.adaln_gate_init,
+            glu_max_autotune_gemm=self.config.glu_max_autotune_gemm,
         )
 
     def create_decoder_layer(
@@ -420,6 +424,7 @@ class ViT(nn.Module):
             dtype=resolved_dtype,
             conditioning_size=self.config.conditioning_size,
             adaln_gate_init=self.config.adaln_gate_init,
+            glu_max_autotune_gemm=self.config.glu_max_autotune_gemm,
         )
 
     def create_cross_attention_layer(
@@ -453,6 +458,7 @@ class ViT(nn.Module):
             dtype=resolved_dtype,
             conditioning_size=self.config.conditioning_size,
             adaln_gate_init=self.config.adaln_gate_init,
+            glu_max_autotune_gemm=self.config.glu_max_autotune_gemm,
         )
 
     def create_head(


### PR DESCRIPTION
## Motivation
Compiled GLU MLPs spend most of their steady-state runtime in GEMMs. PyTorch Inductor's GEMM autotuning improves those kernels on the validated CUDA workload, but its substantially higher cold compilation cost makes it unsuitable as a new default.

## Solution
Add an explicit `glu_max_autotune_gemm` option that selects a separate compiled GLU helper with `max_autotune_gemm=True`. The optimized helper is used only for CUDA inputs with an MLP input width of at least 512; CPU and smaller inputs retain the existing path. Non-GLU activations and MLP quantization are rejected when the option is enabled.

## Changes
- Propagate the opt-in through `ViTConfig`, YAML serialization, transformer layer factories, `NormMLP`, and `AdaNormMLP`.
- Record the setting in component benchmark artifacts while keeping it out of `case_id` for direct baseline/candidate comparisons.
- Add configuration, fallback, quantization, CLI, and CUDA forward/backward parity coverage.
- Document the validated workload, CUDA and small-shape behavior, and cold compilation cost.

Usage:

```python
config = ViTConfig(
    # ...
    activation="swiglu",
    glu_max_autotune_gemm=True,
)
```

### Performance

RTX 3090, PyTorch 2.13.0, native BF16, `B=4, S=256, D=768, FFN=3072`:

| Pass | Default mean | Autotuned mean | Change | p95 change | Peak memory |
| --- | ---: | ---: | ---: | ---: | ---: |
| Forward | 0.4134 ms | 0.3311 ms | 19.9% faster | 19.7% lower | 41.14 to 33.01 MB |
| Backward | 0.8534 ms | 0.7521 ms | 11.9% faster | 11.3% lower | 68.77 to 52.52 MB |
| Forward + backward | 1.1570 ms | 1.0155 ms | 12.2% faster | 11.9% lower | 68.77 to 52.52 MB |

Candidate runs collected 4,144 to 13,713 samples. Default-off means stayed within 0.3% of the pre-change baseline, and the small-batch and FP32-master/BF16-autocast guards improved. A fresh-cache forward-backward compile increased from 4.53 seconds to 21.40 seconds.

## Test plan
- [x] `make test-fused` (70 passed)
- [x] `make test-component_benchmark` (7 passed)
- [x] `make check` (871 passed, 5 skipped, 94% coverage)
- [x] Native-BF16 primary, small-batch, D256/D512/D768 tier, and FP32-master/BF16-autocast benchmarks
- [x] Fresh-cache cold compilation measurement

## Test suite changes (Required when test coverage changed)
- [x] No tests were removed.
- [x] Added configuration validation, YAML round-trip, and transformer-layer propagation tests.
- [x] Added CPU and small-CUDA fallback, quantization rejection, and CUDA output/input-gradient/parameter-gradient parity tests.
- [x] Expanded the component benchmark CLI test to verify artifact recording and stable case IDs.

Generated with Codex