### PR TITLE
Standardize CI on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           PYTHON_VERSION: "3.14"
         run: |
-          test "$(uv --version)" = "uv 0.11.28"
+          test "$(uv --version | cut -d ' ' -f 1-2)" = "uv 0.11.28"
           uv python install "$PYTHON_VERSION"
           uv run --no-project --python "$PYTHON_VERSION" python -c \
             'import os, sys; assert sys.version_info[:2] == tuple(map(int, os.environ["PYTHON_VERSION"].split(".")))'
@@ -106,7 +106,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          test "$(uv --version)" = "uv 0.11.28"
+          test "$(uv --version | cut -d ' ' -f 1-2)" = "uv 0.11.28"
           uv python install "$PYTHON_VERSION"
           uv run --no-project --python "$PYTHON_VERSION" python -c \
             'import os, sys; assert sys.version_info[:2] == tuple(map(int, os.environ["PYTHON_VERSION"].split(".")))'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,160 @@
+name: CI
+
+"on":
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  quality:
+    name: Quality
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.28"
+          checksum: e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224
+          python-version: "3.14"
+          enable-cache: true
+          restore-cache: true
+          save-cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          cache-dependency-glob: |-
+            pyproject.toml
+            uv.lock
+          cache-suffix: ubuntu-x64-uv-0.11.28-python-3.14-torch-2.13.0
+      - name: Verify pinned tools
+        env:
+          PYTHON_VERSION: "3.14"
+        run: |
+          test "$(uv --version)" = "uv 0.11.28"
+          uv python install "$PYTHON_VERSION"
+          uv run --no-project --python "$PYTHON_VERSION" python -c \
+            'import os, sys; assert sys.version_info[:2] == tuple(map(int, os.environ["PYTHON_VERSION"].split(".")))'
+      - name: Install locked dependencies
+        env:
+          PYTHON_VERSION: "3.14"
+        run: uv sync --frozen --all-groups --python "$PYTHON_VERSION"
+      - name: Verify runtime versions
+        env:
+          PYTHON_VERSION: "3.14"
+          TORCH_VERSION: "2.13.0"
+          TORCHAO_VERSION: "0.17.0"
+        run: |
+          uv run --frozen --no-sync python - <<'PY'
+          import importlib.metadata
+          import os
+          import sys
+
+          assert sys.version_info[:2] == tuple(map(int, os.environ["PYTHON_VERSION"].split(".")))
+          assert importlib.metadata.version("torch").partition("+")[0] == os.environ["TORCH_VERSION"]
+          assert importlib.metadata.version("torchao") == os.environ["TORCHAO_VERSION"]
+          PY
+      - name: Check formatting and lint
+        run: make quality
+      - name: Check types
+        run: make types
+
+  tests:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.11"
+            artifact-suffix: py311
+          - python-version: "3.14"
+            artifact-suffix: py314
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.28"
+          checksum: e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          restore-cache: true
+          save-cache: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          cache-dependency-glob: |-
+            pyproject.toml
+            uv.lock
+          cache-suffix: ubuntu-x64-uv-0.11.28-python-${{ matrix.python-version }}-torch-2.13.0
+      - name: Verify pinned tools
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          test "$(uv --version)" = "uv 0.11.28"
+          uv python install "$PYTHON_VERSION"
+          uv run --no-project --python "$PYTHON_VERSION" python -c \
+            'import os, sys; assert sys.version_info[:2] == tuple(map(int, os.environ["PYTHON_VERSION"].split(".")))'
+      - name: Install locked dependencies
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv sync --frozen --all-groups --python "$PYTHON_VERSION"
+      - name: Verify runtime versions
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+          TORCH_VERSION: "2.13.0"
+          TORCHAO_VERSION: "0.17.0"
+        run: |
+          uv run --frozen --no-sync python - <<'PY'
+          import importlib.metadata
+          import os
+          import sys
+
+          assert sys.version_info[:2] == tuple(map(int, os.environ["PYTHON_VERSION"].split(".")))
+          assert importlib.metadata.version("torch").partition("+")[0] == os.environ["TORCH_VERSION"]
+          assert importlib.metadata.version("torchao") == os.environ["TORCHAO_VERSION"]
+          PY
+      - name: Run CPU tests
+        run: make test-ci
+      - name: Validate distribution
+        run: make check-distribution
+      - name: Upload coverage
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-${{ matrix.artifact-suffix }}-${{ github.sha }}
+          path: coverage.xml
+          if-no-files-found: error
+          retention-days: 7
+
+  required:
+    name: Required
+    if: ${{ always() }}
+    needs:
+      - quality
+      - tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every CI job
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+        run: |
+          test "$QUALITY_RESULT" = success
+          test "$TESTS_RESULT" = success

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,41 +1,126 @@
-name: Dependency audit
+name: Dependency health
+run-name: Dependency health ${{ inputs.validation_id || github.run_id }}
 
 "on":
-  pull_request:
-    paths:
-      - .github/workflows/dependency-audit.yml
-      - Makefile
-      - pyproject.toml
-      - uv.lock
-  push:
-    branches:
-      - master
-    paths:
-      - .github/workflows/dependency-audit.yml
-      - Makefile
-      - pyproject.toml
-      - uv.lock
   schedule:
     - cron: "17 6 * * 1"
   workflow_dispatch:
+    inputs:
+      validation_id:
+        description: Correlation UUID for exact-run validation
+        required: false
+        type: string
 
 permissions:
   contents: read
 
+concurrency:
+  group: dependency-health
+  cancel-in-progress: false
+
 jobs:
-  audit:
-    name: Python ${{ matrix.python-version }}
+  security-audit:
+    name: Security audit
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.11"
-          - "3.14"
+    timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install uv
-        run: python -m pip install "uv==0.11.28"
-      - name: Audit locked dependencies
-        run: make audit-dependencies PYTHON_VERSION="${{ matrix.python-version }}"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.28"
+          checksum: e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224
+          python-version: "3.14"
+          enable-cache: true
+          restore-cache: true
+          save-cache: true
+          cache-dependency-glob: |-
+            pyproject.toml
+            uv.lock
+          cache-suffix: ubuntu-x64-uv-0.11.28-python-3.14-torch-2.13.0-security
+      - name: Verify pinned tools
+        run: |
+          test "$(uv --version)" = "uv 0.11.28"
+          uv run --no-project --python 3.14 python -c 'import sys; assert sys.version_info[:2] == (3, 14)'
+      - name: Install locked security tools
+        run: uv sync --frozen --only-group ci-security --python 3.14
+      - name: Run every security scanner
+        id: security
+        continue-on-error: true
+        run: |
+          uv run --frozen --no-sync --only-group ci-security \
+            python tools/run_security_audit.py --report-dir dependency-security
+      - name: Summarize security audit
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Dependency security audit"
+            echo
+            echo '```json'
+            cat dependency-security/manifest.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload security reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dependency-security-${{ github.run_id }}
+          path: dependency-security/
+          if-no-files-found: error
+          retention-days: 7
+      - name: Enforce security result
+        if: ${{ always() }}
+        env:
+          SECURITY_OUTCOME: ${{ steps.security.outcome }}
+        run: test "$SECURITY_OUTCOME" = success
+
+  deprecation-report:
+    name: Deprecation report
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.28"
+          checksum: e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224
+          python-version: "3.14"
+          enable-cache: true
+          restore-cache: true
+          save-cache: true
+          cache-dependency-glob: |-
+            pyproject.toml
+            uv.lock
+          cache-suffix: ubuntu-x64-uv-0.11.28-python-3.14-torch-2.13.0-dependency-report
+      - name: Verify pinned tools
+        run: |
+          test "$(uv --version)" = "uv 0.11.28"
+          uv run --no-project --python 3.14 python -c 'import sys; assert sys.version_info[:2] == (3, 14)'
+      - name: Install locked reporting tools
+        run: uv sync --frozen --only-group ci-dependency-report --python 3.14
+      - name: Build dependency report
+        run: make report-deprecations REPORT_DIR=dependency-deprecations
+      - name: Install locked test dependencies
+        run: uv sync --frozen --all-groups --python 3.14
+      - name: Run tests with deprecation warnings
+        run: |
+          set -o pipefail
+          make test-deprecations 2>&1 | tee dependency-deprecations/deprecation-warnings.log
+      - name: Add dependency report to summary
+        if: ${{ always() }}
+        run: cat dependency-deprecations/dependency-deprecations.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload dependency reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dependency-deprecations-${{ github.run_id }}
+          path: dependency-deprecations/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -43,7 +43,7 @@ jobs:
           cache-suffix: ubuntu-x64-uv-0.11.28-python-3.14-torch-2.13.0-security
       - name: Verify pinned tools
         run: |
-          test "$(uv --version)" = "uv 0.11.28"
+          test "$(uv --version | cut -d ' ' -f 1-2)" = "uv 0.11.28"
           uv run --no-project --python 3.14 python -c 'import sys; assert sys.version_info[:2] == (3, 14)'
       - name: Install locked security tools
         run: uv sync --frozen --only-group ci-security --python 3.14
@@ -101,7 +101,7 @@ jobs:
           cache-suffix: ubuntu-x64-uv-0.11.28-python-3.14-torch-2.13.0-dependency-report
       - name: Verify pinned tools
         run: |
-          test "$(uv --version)" = "uv 0.11.28"
+          test "$(uv --version | cut -d ' ' -f 1-2)" = "uv 0.11.28"
           uv run --no-project --python 3.14 python -c 'import sys; assert sys.version_info[:2] == (3, 14)'
       - name: Install locked reporting tools
         run: uv sync --frozen --only-group ci-dependency-report --python 3.14

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,0 +1,130 @@
+name: Production build
+run-name: Production build ${{ inputs.validation_id || github.run_id }}
+
+"on":
+  workflow_dispatch:
+    inputs:
+      validation_id:
+        description: Correlation UUID for exact-run validation
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-build
+  cancel-in-progress: false
+
+jobs:
+  distributions:
+    name: Distributions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.28"
+          checksum: e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224
+          python-version: "3.14"
+          enable-cache: true
+          restore-cache: true
+          save-cache: true
+          cache-dependency-glob: |-
+            pyproject.toml
+            uv.lock
+          cache-suffix: ubuntu-x64-uv-0.11.28-python-3.11-3.14-torch-2.13.0-production
+      - name: Verify pinned tools and Python boundaries
+        run: |
+          test "$(uv --version)" = "uv 0.11.28"
+          uv python install 3.11 3.14
+          uv run --no-project --python 3.11 python -c 'import sys; assert sys.version_info[:2] == (3, 11)'
+          uv run --no-project --python 3.14 python -c 'import sys; assert sys.version_info[:2] == (3, 14)'
+      - name: Build source distributions
+        run: uv build --no-sources --wheel --sdist --out-dir dist
+      - name: Rebuild wheel from sdist
+        run: |
+          sdist_path="$(find dist -maxdepth 1 -type f -name '*.tar.gz' -print -quit)"
+          test -n "$sdist_path"
+          mkdir rebuilt
+          uv build --no-sources --wheel --out-dir rebuilt "$sdist_path"
+      - name: Validate console scripts in both wheels
+        run: uv run --no-project --python 3.14 python tools/validate_wheel.py dist/*.whl rebuilt/*.whl
+      - name: Clean-install and smoke-test distributions
+        env:
+          SOURCE_ENV: ${{ runner.temp }}/vit-source-wheel
+          REBUILT_ENV: ${{ runner.temp }}/vit-rebuilt-wheel
+        run: |
+          uv venv --python 3.11 "$SOURCE_ENV"
+          uv pip install --python "$SOURCE_ENV/bin/python" dist/*.whl
+          uv venv --python 3.14 "$REBUILT_ENV"
+          uv pip install --python "$REBUILT_ENV/bin/python" rebuilt/*.whl
+
+          "$SOURCE_ENV/bin/python" -c \
+            'import importlib.metadata, sys; assert sys.version_info[:2] == (3, 11); assert importlib.metadata.version("torch").partition("+")[0] == "2.13.0"; assert importlib.metadata.version("torchao") == "0.17.0"'
+          "$REBUILT_ENV/bin/python" -c \
+            'import importlib.metadata, sys; assert sys.version_info[:2] == (3, 14); assert importlib.metadata.version("torch").partition("+")[0] == "2.13.0"; assert importlib.metadata.version("torchao") == "0.17.0"'
+
+          for command in vit-benchmark vit-component-benchmark vit-explain; do
+            "$SOURCE_ENV/bin/$command" --help
+            "$REBUILT_ENV/bin/$command" --help
+          done
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vit-distributions-${{ github.sha }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  cpu-compile:
+    name: CPU compile
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.28"
+          checksum: e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224
+          python-version: "3.14"
+          enable-cache: true
+          restore-cache: true
+          save-cache: true
+          cache-dependency-glob: |-
+            pyproject.toml
+            uv.lock
+          cache-suffix: ubuntu-x64-uv-0.11.28-python-3.14-torch-2.13.0-compile
+      - name: Verify pinned tools
+        run: test "$(uv --version)" = "uv 0.11.28"
+      - name: Install locked dependencies
+        run: uv sync --frozen --all-groups --python 3.14
+      - name: Verify CPU runtime
+        env:
+          CUDA_VISIBLE_DEVICES: ""
+        run: |
+          uv run --frozen --no-sync python - <<'PY'
+          import importlib.metadata
+          import sys
+          import torch
+
+          assert sys.version_info[:2] == (3, 14)
+          assert importlib.metadata.version("torch").partition("+")[0] == "2.13.0"
+          assert importlib.metadata.version("torchao") == "0.17.0"
+          assert not torch.cuda.is_available()
+          PY
+      - name: Run CPU compile tests
+        env:
+          CUDA_VISIBLE_DEVICES: ""
+          TORCHDYNAMO_DISABLE: "0"
+        run: make test-compile-cpu

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -42,7 +42,7 @@ jobs:
           cache-suffix: ubuntu-x64-uv-0.11.28-python-3.11-3.14-torch-2.13.0-production
       - name: Verify pinned tools and Python boundaries
         run: |
-          test "$(uv --version)" = "uv 0.11.28"
+          test "$(uv --version | cut -d ' ' -f 1-2)" = "uv 0.11.28"
           uv python install 3.11 3.14
           uv run --no-project --python 3.11 python -c 'import sys; assert sys.version_info[:2] == (3, 11)'
           uv run --no-project --python 3.14 python -c 'import sys; assert sys.version_info[:2] == (3, 14)'
@@ -106,7 +106,7 @@ jobs:
             uv.lock
           cache-suffix: ubuntu-x64-uv-0.11.28-python-3.14-torch-2.13.0-compile
       - name: Verify pinned tools
-        run: test "$(uv --version)" = "uv 0.11.28"
+        run: test "$(uv --version | cut -d ' ' -f 1-2)" = "uv 0.11.28"
       - name: Install locked dependencies
         run: uv sync --frozen --all-groups --python 3.14
       - name: Verify CPU runtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ The Python-first explainability toolbox lives in `vit/explain/`; its sparse auto
 Unit tests live in `tests/` and follow module-level coverage (`tests/test_vit.py`, `tests/test_attention.py`, etc.).  
 Benchmark tooling and CLI entrypoints live in `benchmark/`; generated benchmark outputs are typically written to
 `benchmark_results/`.  
-Build metadata and tooling configuration are in `pyproject.toml`, `Makefile`, and `.circleci/config.yml`.
+Build metadata and tooling configuration are in `pyproject.toml`, `Makefile`, and `.github/workflows/`. CircleCI
+remains enabled only while the GitHub Actions migration is validated.
 
 ## Architecture & Core Patterns
 Main flow is `Images -> PatchEmbed -> Transformer -> ViTFeatures -> Heads`.
@@ -41,7 +42,16 @@ Use `uv` and Make targets to keep local and CI behavior aligned.
 - `make types`: run static typing with `basedpyright`.
 - `make test`: run pytest with coverage on `vit/`.
 - `make test-ci`: run CI-equivalent tests (`not cuda and not compile`).
+- `make test-compile-cpu`: run CPU `torch.compile` tests with Dynamo enabled and CUDA hidden.
+- `make test-deprecations`: run CPU tests with default deprecation warnings.
+- `make audit-workflows`: audit GitHub Actions with the locked strict `zizmor` configuration.
+- `make report-deprecations REPORT_DIR=<path>`: report yanked, inactive, and Python-incompatible direct pins.
 - `make test-<pattern>`: run targeted tests, e.g. `make test-attention`.
+
+GitHub Actions runs required Linux CPU checks on Python 3.11 and 3.14. The independent Monday dependency-health
+workflow writes security and deprecation reports, and the manual production workflow validates distributions and CPU
+compilation. CUDA CI is deferred until a suitable self-hosted runner is available; GitHub-hosted GPU larger runners
+are not part of the free public-repository runner allocation.
 
 ## Component Benchmark Tool
 Use the local skill `$vit-component-benchmark` for detailed guidance.
@@ -64,7 +74,8 @@ Use `pytest` with `pytest-cov`, `pytest-mock`, and project fixtures in `tests/co
 - Test files should be named `test_<feature>.py`.
 - Prefer parametrized tests for shape/dtype/device combinations.
 - Use markers intentionally: `@pytest.mark.cuda` for GPU-required tests, `@pytest.mark.compile` for `torch.compile`.
-- Run `make test-ci` before opening a PR to match CI filtering.
+- Run `make quality`, `make types`, and `make test-ci` before opening a PR to match required CI.
+- Run `make test-compile-cpu` after changing compilation or activation-checkpointing behavior.
 
 ## Commit & Pull Request Guidelines
 Recent history follows imperative, sentence-style subjects (for example: `Add ...`, `Fix ...`, `Improve ...`), often

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: audit-dependencies check-distribution clean clean-env check quality style tag-version test env upload upload-test
+.PHONY: audit-dependencies audit-workflows check check-distribution clean clean-env deploy init quality report-deprecations style test test-ci test-compile-cpu test-deprecations types
 
 PROJECT=vit
 QUALITY_DIRS=$(PROJECT) tests benchmark tools examples
@@ -7,9 +7,9 @@ UV_VERSION=0.11.28
 UVX=uvx
 UV=$(UVX) --from uv==$(UV_VERSION) uv
 PYTHON=$(UV) run python
-PIP_AUDIT_VERSION=2.10.1
-PIP_AUDIT=$(UVX) --python $(PYTHON_VERSION) --from pip-audit==$(PIP_AUDIT_VERSION) pip-audit
 PYTHON_VERSION?=3.14
+REPORT_DIR?=dependency_reports
+PIP_AUDIT=$(UV) run --isolated --frozen --only-group ci-security --python 3.14 pip-audit
 
 CONFIG_FILE := config.mk
 ifneq ($(wildcard $(CONFIG_FILE)),)
@@ -42,7 +42,18 @@ audit-dependencies: ## audit locked Python dependencies for known public vulnera
 		--cache-dir "$$audit_directory/cache" \
 		--progress-spinner=off \
 		--vulnerability-service pypi \
-		--requirement "$$requirements_file"
+		--requirement "$$requirements_file" \
+		$(if $(AUDIT_REPORT),--format json --output "$(AUDIT_REPORT)")
+
+audit-workflows: ## audit GitHub Actions workflows with locked zizmor
+	$(UV) run --isolated --frozen --only-group ci-security --python 3.14 zizmor \
+		--strict-collection \
+		--pedantic \
+		--offline \
+		--min-severity low \
+		--format json \
+		.github/workflows \
+		$(if $(ZIZMOR_REPORT),> "$(ZIZMOR_REPORT)")
 
 check-distribution: ## build a wheel and validate its console-script targets
 	@dist_dir="$$(mktemp -d)"; \
@@ -96,13 +107,33 @@ test-pdb-%: ## run unit tests matching a pattern with PDB fallback
 	$(PYTHON) -m pytest -rs --pdb -k $* -v ./tests/ 
 
 test-ci: ## runs CI-only tests (excludes cuda and compile tests)
-	export "CUDA_VISIBLE_DEVICES=''" && \
+	export CUDA_VISIBLE_DEVICES="" && \
 	$(PYTHON) -m pytest \
 		-rs \
 		-m "not cuda and not compile" \
 		--cov=./$(PROJECT) \
 		--cov-report=xml \
 		--cov-report=term \
+		./tests/
+
+test-compile-cpu: ## run CPU-only torch.compile tests with Dynamo enabled
+	export CUDA_VISIBLE_DEVICES="" TORCHDYNAMO_DISABLE="0" && \
+	$(PYTHON) -m pytest \
+		-rs \
+		-m "compile and not cuda" \
+		./tests/
+
+report-deprecations: ## report direct dependency yanks, inactivity, and Python conflicts
+	$(UV) run --isolated --frozen --only-group ci-dependency-report --python 3.14 python tools/dependency_report.py \
+		--json-output "$(REPORT_DIR)/dependency-deprecations.json" \
+		--summary-output "$(REPORT_DIR)/dependency-deprecations.md"
+
+test-deprecations: ## run CPU tests with default deprecation warnings
+	export CUDA_VISIBLE_DEVICES="" TORCHDYNAMO_DISABLE="1" && \
+	$(PYTHON) -m pytest \
+		-rs \
+		-m "not cuda and not compile" \
+		-W default \
 		./tests/
 
 types: ## run static type checking

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,22 @@ make audit-dependencies PYTHON_VERSION=3.14
 ```
 
 The target exports every locked dependency group from `uv.lock`, omits the local project, and passes the pinned
-requirements to `pip-audit`. A known public vulnerability makes the command fail. GitHub Actions runs the same checks
-when dependency inputs change, on updates to `master`, on manual request, and every Monday.
+requirements to `pip-audit==2.10.1`. A known public vulnerability makes the command fail. The independent
+`dependency-audit.yml` workflow runs both Python bounds every Monday at 06:17 UTC and on manual request.
+
+The same workflow runs `zizmor==1.28.0` against every GitHub Actions workflow and records scanner versions, commands,
+the UTC query time, the `uv.lock` SHA-256 digest, the supported Python bounds, and the PyPI advisory service. It also
+checks direct, optional, build, and dependency-group pins for PyPI yanks, inactive classifiers, and `requires-python`
+conflicts. Those lifecycle findings are informational; network, parsing, and command errors fail the job. Reports are
+stored as GitHub Actions artifacts for seven days.
+
+Run the additional checks locally with:
+
+```console
+make audit-workflows
+make report-deprecations REPORT_DIR=/tmp/vit-dependency-report
+make test-deprecations
+```
 
 No vulnerability IDs are ignored. Any future `--ignore-vuln` entry must identify the affected package, explain why the
 advisory does not apply, link to supporting evidence, and include a review date in this file.
@@ -25,5 +39,6 @@ advisory does not apply, link to supporting evidence, and include a review date 
 | Project source | Not covered by `pip-audit`; formatting, linting, typing, and tests remain separate quality gates. |
 | Native libraries bundled inside wheels | Not covered unless the vulnerability is reported against the Python package. Review upstream package advisories during dependency updates. |
 | Non-Linux dependency variants | Not covered by the scheduled audit because the supported CI environment is Linux. Review platform-specific changes when adding another CI platform. |
-| CircleCI images and the Codecov orb | Not covered by `pip-audit`. Review their release and security notices when changing the versioned CI references. |
-| GitHub Actions | `actions/checkout` is pinned to a full commit SHA. Review the upstream release before changing it. |
+| CircleCI images and the Codecov orb | Retained only for the CI migration overlap and not covered by `pip-audit`. |
+| GitHub Actions | Every action is pinned to a full commit SHA. Locked `zizmor` checks workflow structure and permissions weekly. |
+| CUDA execution | Deferred. Required CI is Linux CPU-only until a suitable self-hosted CUDA runner is available. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ force-single-line = false
 combine-as-imports = true
 
 [tool.basedpyright]
-include = ["vit", "tests", "benchmark", "examples"]
+include = ["vit", "tests", "benchmark", "tools", "examples"]
 exclude = [
   "**/node_modules",
   "**/__pycache__",
@@ -64,7 +64,7 @@ version-file = "vit/_version.py"
 
 [tool.pytest.ini_options]
 markers = [
-  "ci_skip",
+  "compile",
   "cuda",
 ]
 filterwarnings = []
@@ -107,6 +107,15 @@ dev = [
     "pdbpp==0.12.1",
     {include-group = "benchmarking"},
     {include-group = "explainability"},
+]
+
+ci-security = [
+    "pip-audit==2.10.1",
+    "zizmor==1.28.0",
+]
+
+ci-dependency-report = [
+    "packaging==26.2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def pytest_runtest_setup(item):
     handle_cuda_mark(item)
 
 
-@pytest.fixture(params=["cpu", "cuda:0"])
+@pytest.fixture(params=["cpu", pytest.param("cuda:0", marks=pytest.mark.cuda)])
 def device(request):
     if request.param == "cuda:0" and not cuda_available():
         pytest.skip("Test requires CUDA and device is not ready")

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -236,7 +236,7 @@ class TestActivationCheckpointing:
         # Checkpointing should use less memory
         assert mem_ckpt < mem_no_ckpt, f"Expected memory reduction, got {mem_ckpt} vs {mem_no_ckpt}"
 
-    @pytest.mark.ci_skip
+    @pytest.mark.compile
     def test_checkpointing_with_torch_compile(self, device, config):
         """Verify checkpointing works when model is torch.compiled."""
         config = replace(config, activation_checkpointing=True)

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,176 @@
+"""Contract tests for the repository's GitHub Actions workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+WORKFLOW_DIRECTORY = REPOSITORY_ROOT / ".github" / "workflows"
+MAKEFILE = REPOSITORY_ROOT / "Makefile"
+CIRCLECI_CONFIGURATION = REPOSITORY_ROOT / ".circleci" / "config.yml"
+CODECOV_CONFIGURATION = REPOSITORY_ROOT / "codecov.yml"
+CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+SETUP_UV_ACTION = "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9"
+UPLOAD_ARTIFACT_ACTION = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+UV_VERSION = "0.11.28"
+UV_CHECKSUM = "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224"
+
+
+def load_workflow(name: str) -> dict[str, Any]:
+    """Load a workflow as a mapping."""
+    with (WORKFLOW_DIRECTORY / name).open() as workflow_file:
+        workflow = yaml.safe_load(workflow_file)
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def workflow_steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return every step from every job in a workflow."""
+    return [step for job in workflow["jobs"].values() for step in job["steps"]]
+
+
+def test_ci_workflow_contract() -> None:
+    workflow = load_workflow("ci.yml")
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert set(workflow["on"]) == {"pull_request", "push", "workflow_dispatch"}
+    assert workflow["on"]["pull_request"]["branches"] == ["master"]
+    assert workflow["on"]["push"]["branches"] == ["master"]
+    assert workflow["concurrency"]["group"] == "ci-${{ github.event.pull_request.number || github.ref }}"
+    assert workflow["concurrency"]["cancel-in-progress"] == "${{ github.event_name == 'pull_request' }}"
+
+    jobs = workflow["jobs"]
+    assert jobs["quality"]["name"] == "Quality"
+    assert jobs["quality"]["runs-on"] == "ubuntu-24.04"
+    assert jobs["quality"]["timeout-minutes"] == 15
+    assert jobs["tests"]["strategy"]["matrix"]["include"] == [
+        {"python-version": "3.11", "artifact-suffix": "py311"},
+        {"python-version": "3.14", "artifact-suffix": "py314"},
+    ]
+    assert jobs["tests"]["runs-on"] == "ubuntu-24.04"
+    assert jobs["tests"]["timeout-minutes"] == 25
+    assert jobs["required"]["name"] == "Required"
+    assert jobs["required"]["needs"] == ["quality", "tests"]
+    assert jobs["required"]["if"] == "${{ always() }}"
+    assert jobs["required"]["runs-on"] == "ubuntu-24.04"
+    assert jobs["required"]["timeout-minutes"] == 5
+
+    required_step = jobs["required"]["steps"][0]
+    assert required_step["env"] == {
+        "QUALITY_RESULT": "${{ needs.quality.result }}",
+        "TESTS_RESULT": "${{ needs.tests.result }}",
+    }
+    assert '"$QUALITY_RESULT" = success' in required_step["run"]
+    assert '"$TESTS_RESULT" = success' in required_step["run"]
+
+    artifact_steps = [step for step in workflow_steps(workflow) if step.get("uses") == UPLOAD_ARTIFACT_ACTION]
+    assert len(artifact_steps) == 1
+    assert artifact_steps[0]["with"]["name"] == "coverage-${{ matrix.artifact-suffix }}-${{ github.sha }}"
+    assert artifact_steps[0]["with"]["retention-days"] == 7
+
+
+@pytest.mark.parametrize("workflow_name", ["ci.yml", "dependency-audit.yml", "production-build.yml"])
+def test_workflows_pin_actions_and_harden_checkout(workflow_name: str) -> None:
+    workflow = load_workflow(workflow_name)
+    steps = workflow_steps(workflow)
+
+    for step in steps:
+        action = step.get("uses")
+        if action is None:
+            continue
+        assert action in {CHECKOUT_ACTION, SETUP_UV_ACTION, UPLOAD_ARTIFACT_ACTION}
+        if action == CHECKOUT_ACTION:
+            assert step["with"]["persist-credentials"] is False
+        elif action == SETUP_UV_ACTION:
+            assert step["with"]["version"] == UV_VERSION
+            assert step["with"]["checksum"] == UV_CHECKSUM
+
+
+def test_ci_cache_is_restored_for_forks_but_saved_only_by_trusted_writers() -> None:
+    workflow = load_workflow("ci.yml")
+    setup_steps = [step for step in workflow_steps(workflow) if step.get("uses") == SETUP_UV_ACTION]
+
+    assert setup_steps
+    for step in setup_steps:
+        assert step["with"]["enable-cache"] is True
+        assert step["with"]["restore-cache"] is True
+        assert step["with"]["save-cache"] == (
+            "${{ github.event_name != 'pull_request' || "
+            "github.event.pull_request.head.repo.full_name == github.repository }}"
+        )
+        assert step["with"]["cache-dependency-glob"] == "pyproject.toml\nuv.lock"
+        assert "uv-0.11.28" in step["with"]["cache-suffix"]
+        assert "torch-2.13.0" in step["with"]["cache-suffix"]
+
+
+def test_dependency_health_workflow_contract() -> None:
+    workflow = load_workflow("dependency-audit.yml")
+
+    assert workflow["name"] == "Dependency health"
+    assert workflow["permissions"] == {"contents": "read"}
+    assert set(workflow["on"]) == {"schedule", "workflow_dispatch"}
+    assert workflow["on"]["schedule"] == [{"cron": "17 6 * * 1"}]
+    assert workflow["on"]["workflow_dispatch"]["inputs"]["validation_id"]["required"] is False
+    assert workflow["concurrency"] == {"group": "dependency-health", "cancel-in-progress": False}
+
+    jobs = workflow["jobs"]
+    assert jobs["security-audit"]["name"] == "Security audit"
+    assert jobs["security-audit"]["runs-on"] == "ubuntu-24.04"
+    assert jobs["security-audit"]["timeout-minutes"] == 20
+    assert jobs["deprecation-report"]["name"] == "Deprecation report"
+    assert jobs["deprecation-report"]["runs-on"] == "ubuntu-24.04"
+    assert jobs["deprecation-report"]["timeout-minutes"] == 25
+
+    artifact_steps = [step for step in workflow_steps(workflow) if step.get("uses") == UPLOAD_ARTIFACT_ACTION]
+    assert {step["with"]["name"] for step in artifact_steps} == {
+        "dependency-security-${{ github.run_id }}",
+        "dependency-deprecations-${{ github.run_id }}",
+    }
+    assert all(step["with"]["retention-days"] == 7 for step in artifact_steps)
+
+
+def test_production_build_is_manual_only_during_overlap() -> None:
+    workflow = load_workflow("production-build.yml")
+
+    assert workflow["name"] == "Production build"
+    assert workflow["permissions"] == {"contents": "read"}
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+    assert workflow["on"]["workflow_dispatch"]["inputs"]["validation_id"]["required"] is False
+    assert workflow["concurrency"] == {"group": "production-build", "cancel-in-progress": False}
+
+    jobs = workflow["jobs"]
+    assert jobs["distributions"]["name"] == "Distributions"
+    assert jobs["distributions"]["runs-on"] == "ubuntu-24.04"
+    assert jobs["distributions"]["timeout-minutes"] == 30
+    assert jobs["cpu-compile"]["name"] == "CPU compile"
+    assert jobs["cpu-compile"]["runs-on"] == "ubuntu-24.04"
+    assert jobs["cpu-compile"]["timeout-minutes"] == 30
+
+    compile_steps = [step for step in jobs["cpu-compile"]["steps"] if step.get("run") == "make test-compile-cpu"]
+    assert len(compile_steps) == 1
+    assert compile_steps[0]["env"]["CUDA_VISIBLE_DEVICES"] == ""
+    assert compile_steps[0]["env"]["TORCHDYNAMO_DISABLE"] == "0"
+
+    artifact_steps = [step for step in workflow_steps(workflow) if step.get("uses") == UPLOAD_ARTIFACT_ACTION]
+    assert len(artifact_steps) == 1
+    assert artifact_steps[0]["with"]["name"] == "vit-distributions-${{ github.sha }}"
+    assert artifact_steps[0]["with"]["retention-days"] == 7
+
+
+def test_circleci_and_codecov_remain_enabled_during_overlap() -> None:
+    assert CIRCLECI_CONFIGURATION.is_file()
+    assert CODECOV_CONFIGURATION.is_file()
+
+
+def test_makefile_selects_only_cpu_compile_tests() -> None:
+    makefile = MAKEFILE.read_text()
+
+    assert "test-compile-cpu:" in makefile
+    assert 'TORCHDYNAMO_DISABLE="0"' in makefile
+    assert 'CUDA_VISIBLE_DEVICES=""' in makefile
+    assert '-m "compile and not cuda"' in makefile

--- a/tests/test_compile_ci_contract.py
+++ b/tests/test_compile_ci_contract.py
@@ -1,0 +1,15 @@
+"""CI selection contract for torch.compile coverage."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests import test_checkpointing
+
+
+def test_checkpointing_compile_regression_uses_compile_marker() -> None:
+    compile_test = test_checkpointing.TestActivationCheckpointing.test_checkpointing_with_torch_compile
+    marks = getattr(compile_test, "pytestmark", ())
+
+    assert any(isinstance(mark, pytest.Mark) and mark.name == "compile" for mark in marks)
+    assert not any(isinstance(mark, pytest.Mark) and mark.name == "ci_skip" for mark in marks)

--- a/tests/test_dependency_reports.py
+++ b/tests/test_dependency_reports.py
@@ -1,0 +1,109 @@
+"""Tests for dependency-health report helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from subprocess import CompletedProcess
+from typing import Any
+
+import pytest
+
+from tools.dependency_report import DependencyReportError, build_report
+from tools.run_security_audit import Scan, run_scans, scans_succeeded
+
+
+def test_security_orchestration_runs_every_scanner_before_failing(tmp_path: Path) -> None:
+    calls: list[tuple[str, ...]] = []
+    scans = (
+        Scan("python-3.11", ("audit", "3.11"), tmp_path / "python-3.11.json"),
+        Scan("python-3.14", ("audit", "3.14"), tmp_path / "python-3.14.json"),
+        Scan("workflows", ("zizmor",), tmp_path / "workflows.json"),
+    )
+
+    def runner(command: tuple[str, ...]) -> CompletedProcess[str]:
+        calls.append(command)
+        report_path = scans[len(calls) - 1].report_path
+        report_path.write_text(json.dumps({"findings": []}))
+        return CompletedProcess(command, 1 if len(calls) == 1 else 0)
+
+    results = run_scans(scans, runner=runner)
+
+    assert calls == [scan.command for scan in scans]
+    assert [result.exit_code for result in results] == [1, 0, 0]
+    assert all(result.report_written for result in results)
+    assert not scans_succeeded(results)
+
+
+def test_security_orchestration_rejects_a_missing_report(tmp_path: Path) -> None:
+    scan = Scan("workflows", ("zizmor",), tmp_path / "workflows.json")
+
+    results = run_scans((scan,), runner=lambda command: CompletedProcess(command, 0))
+
+    assert not results[0].report_written
+    assert not scans_succeeded(results)
+
+
+def test_dependency_findings_do_not_fail_reporting(tmp_path: Path) -> None:
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(
+        """
+[build-system]
+requires = ["build-tool==1.0.0"]
+
+[project]
+requires-python = ">=3.11,<3.15"
+dependencies = ["runtime==2.0.0"]
+
+[project.optional-dependencies]
+extra = ["inactive==3.0.0"]
+
+[dependency-groups]
+dev = ["future-only==4.0.0"]
+""".strip()
+    )
+    responses: dict[tuple[str, str], dict[str, Any]] = {
+        ("build-tool", "1.0.0"): {"info": {"classifiers": [], "requires_python": ">=3.11", "yanked": True}},
+        ("runtime", "2.0.0"): {"info": {"classifiers": [], "requires_python": ">=3.11", "yanked": False}},
+        (
+            "inactive",
+            "3.0.0",
+        ): {
+            "info": {
+                "classifiers": ["Development Status :: 7 - Inactive"],
+                "requires_python": ">=3.11",
+                "yanked": False,
+            }
+        },
+        ("future-only", "4.0.0"): {"info": {"classifiers": [], "requires_python": ">=3.15", "yanked": False}},
+    }
+
+    report = build_report(
+        pyproject_path,
+        python_versions=("3.11", "3.14"),
+        fetch_project=lambda name, version: responses[(name, version)],
+    )
+
+    assert report["status"] == "findings"
+    assert {finding["kind"] for finding in report["findings"]} == {
+        "inactive",
+        "requires-python",
+        "yanked",
+    }
+
+
+def test_dependency_reporting_raises_on_network_or_parse_errors(tmp_path: Path) -> None:
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(
+        """
+[project]
+requires-python = ">=3.11,<3.15"
+dependencies = ["runtime==2.0.0"]
+""".strip()
+    )
+
+    def failing_fetcher(name: str, version: str) -> dict[str, Any]:
+        raise OSError(f"offline while fetching {name} {version}")
+
+    with pytest.raises(DependencyReportError, match="offline"):
+        build_report(pyproject_path, python_versions=("3.14",), fetch_project=failing_fetcher)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -7,15 +7,20 @@ import yaml
 
 PROJECT_ROOT = Path(__file__).parents[1]
 DEPENDENCY_AUDIT_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "dependency-audit.yml"
-SUPPORTED_PYTHON_BOUNDS = {"3.11", "3.14"}
 
 
 def test_dependency_audit_workflow_is_scheduled_and_covers_supported_python_bounds() -> None:
     workflow = yaml.safe_load(DEPENDENCY_AUDIT_WORKFLOW.read_text())
 
     assert workflow["permissions"] == {"contents": "read"}
-    assert workflow["on"]["schedule"]
-    assert set(workflow["jobs"]["audit"]["strategy"]["matrix"]["python-version"]) == SUPPORTED_PYTHON_BOUNDS
+    assert workflow["on"]["schedule"] == [{"cron": "17 6 * * 1"}]
+    assert set(workflow["jobs"]) == {"security-audit", "deprecation-report"}
+    security_command = next(
+        step["run"]
+        for step in workflow["jobs"]["security-audit"]["steps"]
+        if step.get("name") == "Run every security scanner"
+    )
+    assert "tools/run_security_audit.py" in security_command
 
 
 def test_dependency_audit_target_runs_scanner_on_requested_python() -> None:
@@ -27,7 +32,9 @@ def test_dependency_audit_target_runs_scanner_on_requested_python() -> None:
         check=True,
     )
 
-    assert "uvx --python 3.11 --from pip-audit==2.10.1 pip-audit" in result.stdout
+    assert '--python "3.11"' in result.stdout
+    assert "--only-group ci-security" in result.stdout
+    assert "pip-audit" in result.stdout
 
 
 @pytest.mark.parametrize(("scanner", "should_succeed"), [("true", True), ("false", False)])

--- a/tools/dependency_report.py
+++ b/tools/dependency_report.py
@@ -1,0 +1,262 @@
+"""Report yanked, inactive, and Python-incompatible direct dependency pins."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from packaging.markers import default_environment
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import Version
+
+
+FetchProject = Callable[[str, str], Mapping[str, Any]]
+PYPI_JSON_BASE = "https://pypi.org/pypi"
+INACTIVE_CLASSIFIER = "Development Status :: 7 - Inactive"
+
+
+class DependencyReportError(RuntimeError):
+    """Raised when dependency metadata cannot be collected or interpreted."""
+
+
+@dataclass(frozen=True)
+class PinnedDependency:
+    """An exact dependency pin and the pyproject section that declared it."""
+
+    name: str
+    version: str
+    requirement: str
+    source: str
+
+
+def _requirement_strings(values: object, source: str) -> Iterable[tuple[str, str]]:
+    if not isinstance(values, list):
+        raise DependencyReportError(f"{source} must be an array")
+    for value in values:
+        if isinstance(value, str):
+            yield value, source
+        elif not (isinstance(value, dict) and set(value) == {"include-group"}):
+            raise DependencyReportError(f"Unsupported dependency entry in {source}: {value!r}")
+
+
+def _declared_requirements(pyproject: Mapping[str, Any]) -> Iterable[tuple[str, str]]:
+    build_system = pyproject.get("build-system", {})
+    project = pyproject.get("project", {})
+    yield from _requirement_strings(build_system.get("requires", []), "build-system.requires")
+    yield from _requirement_strings(project.get("dependencies", []), "project.dependencies")
+
+    for group_name, requirements in project.get("optional-dependencies", {}).items():
+        yield from _requirement_strings(requirements, f"project.optional-dependencies.{group_name}")
+    for group_name, requirements in pyproject.get("dependency-groups", {}).items():
+        yield from _requirement_strings(requirements, f"dependency-groups.{group_name}")
+
+
+def _exact_version(requirement: Requirement) -> str | None:
+    specifiers = list(requirement.specifier)
+    if len(specifiers) != 1 or specifiers[0].operator != "==" or "*" in specifiers[0].version:
+        return None
+    return specifiers[0].version
+
+
+def _collect_pins(pyproject: Mapping[str, Any]) -> tuple[PinnedDependency, ...]:
+    pins: dict[tuple[str, str, str], PinnedDependency] = {}
+    for requirement_text, source in _declared_requirements(pyproject):
+        try:
+            requirement = Requirement(requirement_text)
+        except InvalidRequirement as error:
+            raise DependencyReportError(f"Invalid requirement in {source}: {requirement_text}") from error
+        version = _exact_version(requirement)
+        if version is None:
+            continue
+        key = (requirement.name.lower(), version, source)
+        pins[key] = PinnedDependency(
+            name=requirement.name,
+            version=version,
+            requirement=requirement_text,
+            source=source,
+        )
+    return tuple(sorted(pins.values(), key=lambda pin: (pin.name.lower(), pin.version, pin.source)))
+
+
+def fetch_pypi_project(name: str, version: str) -> Mapping[str, Any]:
+    """Fetch PyPI metadata for one exact project version."""
+    encoded_name = urllib.parse.quote(name, safe="")
+    encoded_version = urllib.parse.quote(version, safe="")
+    request = urllib.request.Request(
+        f"{PYPI_JSON_BASE}/{encoded_name}/{encoded_version}/json",
+        headers={"Accept": "application/json", "User-Agent": "vit-dependency-report/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        raise DependencyReportError(f"Unable to fetch PyPI metadata for {name} {version}: {error}") from error
+    if not isinstance(payload, dict):
+        raise DependencyReportError(f"PyPI returned an invalid payload for {name} {version}")
+    return payload
+
+
+def _marker_applies(requirement_text: str, python_version: str) -> bool:
+    requirement = Requirement(requirement_text)
+    if requirement.marker is None:
+        return True
+    environment: dict[str, str] = {str(key): str(value) for key, value in default_environment().items()}
+    environment["python_version"] = python_version
+    environment["python_full_version"] = f"{python_version}.0"
+    return requirement.marker.evaluate(environment)
+
+
+def _requires_python_supports(specifier: str | None, python_version: str) -> bool:
+    if not specifier:
+        return True
+    try:
+        return Version(f"{python_version}.0") in SpecifierSet(specifier)
+    except InvalidSpecifier as error:
+        raise DependencyReportError(f"Invalid requires-python metadata {specifier!r}") from error
+
+
+def build_report(
+    pyproject_path: Path,
+    *,
+    python_versions: Sequence[str],
+    fetch_project: FetchProject = fetch_pypi_project,
+) -> dict[str, Any]:
+    """Build a report; findings are data, while collection errors raise."""
+    try:
+        with pyproject_path.open("rb") as pyproject_file:
+            pyproject = tomllib.load(pyproject_file)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise DependencyReportError(f"Unable to parse {pyproject_path}: {error}") from error
+
+    pins = _collect_pins(pyproject)
+    findings: list[dict[str, Any]] = []
+    packages: list[dict[str, Any]] = []
+    metadata_cache: dict[tuple[str, str], Mapping[str, Any]] = {}
+
+    for pin in pins:
+        cache_key = (pin.name.lower(), pin.version)
+        if cache_key not in metadata_cache:
+            try:
+                metadata_cache[cache_key] = fetch_project(pin.name, pin.version)
+            except DependencyReportError:
+                raise
+            except Exception as error:
+                raise DependencyReportError(
+                    f"Unable to fetch metadata for {pin.name} {pin.version}: {error}"
+                ) from error
+
+        payload = metadata_cache[cache_key]
+        info = payload.get("info")
+        if not isinstance(info, Mapping):
+            raise DependencyReportError(f"PyPI metadata for {pin.name} {pin.version} has no info mapping")
+
+        classifiers = info.get("classifiers") or []
+        if not isinstance(classifiers, list) or not all(isinstance(value, str) for value in classifiers):
+            raise DependencyReportError(f"PyPI classifiers for {pin.name} {pin.version} are invalid")
+        requires_python_value = info.get("requires_python")
+        requires_python = requires_python_value if isinstance(requires_python_value, str) else None
+        yanked = bool(info.get("yanked", False))
+
+        package = asdict(pin) | {
+            "requires_python": requires_python,
+            "yanked": yanked,
+            "inactive": INACTIVE_CLASSIFIER in classifiers,
+        }
+        packages.append(package)
+        if yanked:
+            findings.append({"kind": "yanked", "dependency": pin.name, "version": pin.version, "source": pin.source})
+        if INACTIVE_CLASSIFIER in classifiers:
+            findings.append({"kind": "inactive", "dependency": pin.name, "version": pin.version, "source": pin.source})
+
+        for python_version in python_versions:
+            if _marker_applies(pin.requirement, python_version) and not _requires_python_supports(
+                requires_python, python_version
+            ):
+                findings.append(
+                    {
+                        "kind": "requires-python",
+                        "dependency": pin.name,
+                        "version": pin.version,
+                        "source": pin.source,
+                        "python_version": python_version,
+                        "requires_python": requires_python,
+                    }
+                )
+
+    return {
+        "schema_version": 1,
+        "created_at_utc": datetime.now(UTC).isoformat(),
+        "pyproject": str(pyproject_path),
+        "python_versions": list(python_versions),
+        "pypi_service": PYPI_JSON_BASE,
+        "status": "findings" if findings else "ok",
+        "packages": packages,
+        "findings": findings,
+    }
+
+
+def _markdown_summary(report: Mapping[str, Any]) -> str:
+    findings = report["findings"]
+    lines = [
+        "## Dependency deprecation report",
+        "",
+        f"Checked {len(report['packages'])} exact direct pins for Python {', '.join(report['python_versions'])}.",
+        "",
+    ]
+    if not findings:
+        lines.append("No yanked releases, inactive classifiers, or `requires-python` conflicts were found.")
+    else:
+        lines.extend(("| Finding | Dependency | Version | Source | Detail |", "|---|---|---|---|---|"))
+        for finding in findings:
+            detail = ""
+            if finding["kind"] == "requires-python":
+                detail = f"Python {finding['python_version']} not in `{finding['requires_python'] or 'unspecified'}`"
+            lines.append(
+                f"| {finding['kind']} | {finding['dependency']} | {finding['version']} | "
+                f"{finding['source']} | {detail} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """Write JSON and Markdown dependency-health reports."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", type=Path, default=Path("pyproject.toml"))
+    parser.add_argument("--json-output", type=Path, required=True)
+    parser.add_argument("--summary-output", type=Path, required=True)
+    parser.add_argument("--python-version", action="append", dest="python_versions")
+    args = parser.parse_args()
+    python_versions = tuple(args.python_versions or ("3.11", "3.14"))
+
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        report = build_report(args.pyproject, python_versions=python_versions)
+    except DependencyReportError as error:
+        error_report = {
+            "schema_version": 1,
+            "created_at_utc": datetime.now(UTC).isoformat(),
+            "status": "error",
+            "error": str(error),
+        }
+        args.json_output.write_text(json.dumps(error_report, indent=2, sort_keys=True) + "\n")
+        args.summary_output.write_text(f"## Dependency deprecation report\n\nCollection failed: {error}\n")
+        return 2
+
+    args.json_output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    args.summary_output.write_text(_markdown_summary(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_security_audit.py
+++ b/tools/run_security_audit.py
@@ -1,0 +1,159 @@
+"""Run every locked security scanner and write a single execution manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import tomllib
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+Runner = Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]
+PYTHON_VERSIONS = ("3.11", "3.14")
+VULNERABILITY_SERVICE = "PyPI advisory database"
+
+
+@dataclass(frozen=True)
+class Scan:
+    """One scanner invocation and its expected machine-readable report."""
+
+    name: str
+    command: tuple[str, ...]
+    report_path: Path
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Recorded result for one scanner invocation."""
+
+    name: str
+    command: tuple[str, ...]
+    exit_code: int
+    report_path: str
+    report_written: bool
+
+
+def _default_runner(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, check=False, text=True)
+
+
+def run_scans(scans: Sequence[Scan], *, runner: Runner = _default_runner) -> tuple[ScanResult, ...]:
+    """Run all scanners even when an earlier scanner reports a finding."""
+    results = []
+    for scan in scans:
+        completed = runner(scan.command)
+        results.append(
+            ScanResult(
+                name=scan.name,
+                command=scan.command,
+                exit_code=completed.returncode,
+                report_path=str(scan.report_path),
+                report_written=scan.report_path.is_file(),
+            )
+        )
+    return tuple(results)
+
+
+def scans_succeeded(results: Sequence[ScanResult]) -> bool:
+    """Return whether every scanner completed cleanly and wrote its report."""
+    return all(result.exit_code == 0 and result.report_written for result in results)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _tool_version(command: tuple[str, ...]) -> dict[str, str | int]:
+    completed = subprocess.run(command, check=False, text=True, capture_output=True)
+    output = (completed.stdout or completed.stderr).strip()
+    return {"command": " ".join(command), "exit_code": completed.returncode, "output": output}
+
+
+def _project_metadata(pyproject_path: Path) -> tuple[str, list[str]]:
+    with pyproject_path.open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+    dependency_groups = pyproject.get("dependency-groups", {})
+    return str(pyproject["project"]["requires-python"]), ["project", *sorted(dependency_groups)]
+
+
+def _build_scans(report_directory: Path) -> tuple[Scan, ...]:
+    scans = [
+        Scan(
+            name=f"pip-audit-python-{python_version}",
+            command=(
+                "make",
+                "audit-dependencies",
+                f"PYTHON_VERSION={python_version}",
+                f"AUDIT_REPORT={report_directory / f'pip-audit-python-{python_version}.json'}",
+            ),
+            report_path=report_directory / f"pip-audit-python-{python_version}.json",
+        )
+        for python_version in PYTHON_VERSIONS
+    ]
+    scans.append(
+        Scan(
+            name="zizmor-workflows",
+            command=("make", "audit-workflows", f"ZIZMOR_REPORT={report_directory / 'zizmor-workflows.json'}"),
+            report_path=report_directory / "zizmor-workflows.json",
+        )
+    )
+    return tuple(scans)
+
+
+def main() -> int:
+    """Run the security audit and write its reproducibility manifest."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report-dir", type=Path, required=True)
+    parser.add_argument("--repository-root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    repository_root = args.repository_root.resolve()
+    report_directory = args.report_dir.resolve()
+    report_directory.mkdir(parents=True, exist_ok=True)
+    scans = _build_scans(report_directory)
+    python_bounds, included_dependency_groups = _project_metadata(repository_root / "pyproject.toml")
+
+    results = run_scans(scans)
+    security_tool_prefix = (
+        "uv",
+        "run",
+        "--isolated",
+        "--frozen",
+        "--only-group",
+        "ci-security",
+        "--python",
+        "3.14",
+    )
+    tools = {
+        "uv": _tool_version(("uv", "--version")),
+        "pip-audit": _tool_version((*security_tool_prefix, "pip-audit", "--version")),
+        "zizmor": _tool_version((*security_tool_prefix, "zizmor", "--version")),
+    }
+    manifest = {
+        "schema_version": 1,
+        "created_at_utc": datetime.now(UTC).isoformat(),
+        "repository_root": str(repository_root),
+        "uv_lock_sha256": _sha256(repository_root / "uv.lock"),
+        "python_bounds": python_bounds,
+        "python_versions": list(PYTHON_VERSIONS),
+        "included_dependency_groups": included_dependency_groups,
+        "vulnerability_service": VULNERABILITY_SERVICE,
+        "tools": tools,
+        "scans": [asdict(result) for result in results],
+    }
+    (report_directory / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    tools_succeeded = all(tool["exit_code"] == 0 for tool in tools.values())
+    return 0 if scans_succeeded(results) and tools_succeeded else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,33 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
+]
+
+[[package]]
 name = "captum"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -33,6 +60,89 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/9e/f31758e20c3d2b42b05420936b75f663e7aeae9ba63b84aee5cad1b044a3/captum-0.9.0.tar.gz", hash = "sha256:e4868e22b68224f1a5355d2b7966803c021cf9fe5d893f51f587b4002a666b54", size = 363381, upload-time = "2026-04-17T06:11:39.577Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/75/c99571fee171bb9d34d3e1df5fdb16d57e2c4c15339eb220e6e6e4539f1c/captum-0.9.0-py3-none-any.whl", hash = "sha256:cda38e1d42c37591d71560bb2f5813ac4cae8d8543afac45279c7efd5945997e", size = 455196, upload-time = "2026-04-17T06:11:38.229Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -303,6 +413,31 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "fancycompleter"
 version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -380,6 +515,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -507,6 +651,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
     { url = "https://files.pythonhosted.org/packages/52/7d/7157f9bba6b455cfb4632ed411e199fc8b8977642c2b12082e1bd9e6d173/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16", size = 77603, upload-time = "2026-03-09T13:15:50.945Z" },
     { url = "https://files.pythonhosted.org/packages/0a/dd/8050c947d435c8d4bc94e3252f4d8bb8a76cfb424f043a8680be637a57f1/kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1", size = 73558, upload-time = "2026-03-09T13:15:52.112Z" },
+]
+
+[[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -649,12 +817,84 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/6b/e9b1cdc042c4458801d2545ed782a95f3d6ba8e270cce8745b8603c7f748/msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22", size = 82812, upload-time = "2026-06-18T16:12:45.022Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3a/dd518a1bf78ed1e9ad8afe57307c079a00eafe4b3068932a27ca1ea56b4f/msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5", size = 82739, upload-time = "2026-06-18T16:12:46.025Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/7ba9e1542bf0771a27b8b37c1316e3f95ae9d748fd765284655c476ad4ef/msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06", size = 414233, upload-time = "2026-06-18T16:12:47.029Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/671d81534ea0e2b0e8a121be100020da09eb78861fe3aa8f3ef7dcd3bed1/msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4", size = 423843, upload-time = "2026-06-18T16:12:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b6/e5c737515ed1f166664b87601b532f58cbb73d8aa6a90b99f7c2c5037e8e/msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8", size = 390772, upload-time = "2026-06-18T16:12:49.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/46/62ed8c2e87d7021eab19921594d961ef3aa3794eec76c716dc30f3bfd433/msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b", size = 409559, upload-time = "2026-06-18T16:12:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/59aa3887b860bbf43532835e192b1c388a17590d6068ae4f8b2bc74c906e/msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e", size = 387838, upload-time = "2026-06-18T16:12:52.161Z" },
+    { url = "https://files.pythonhosted.org/packages/09/11/f8563e471093420cf6478cb3271a0175d8402b82d879783d4035d2d03360/msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f", size = 421732, upload-time = "2026-06-18T16:12:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cf/e673683c4c6c90c1022b24c65af4b03eda72b182a1176ef6449069d66acc/msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d", size = 64091, upload-time = "2026-06-18T16:12:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/ca212739d179f9083bff2c7c08c24101c3555a334fadc2b876b18768a3ae/msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8", size = 70462, upload-time = "2026-06-18T16:12:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/be/6798347b425e26f35db82e69dd83c09716c856a3714e7bffc4c0860fd830/msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66", size = 65059, upload-time = "2026-06-18T16:12:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
 ]
 
 [[package]]
@@ -971,6 +1211,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1057,12 +1306,88 @@ wheels = [
 ]
 
 [[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -1233,6 +1558,34 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.21"
 source = { registry = "https://pypi.org/simple" }
@@ -1273,6 +1626,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -1339,6 +1701,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]
@@ -1432,6 +1803,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
 name = "vit"
 source = { editable = "." }
 dependencies = [
@@ -1457,6 +1837,13 @@ explainability = [
 benchmarking = [
     { name = "matplotlib" },
     { name = "tqdm" },
+]
+ci-dependency-report = [
+    { name = "packaging" },
+]
+ci-security = [
+    { name = "pip-audit" },
+    { name = "zizmor" },
 ]
 dev = [
     { name = "basedpyright" },
@@ -1498,6 +1885,11 @@ benchmarking = [
     { name = "matplotlib", specifier = "==3.11.0" },
     { name = "tqdm", specifier = "==4.68.4" },
 ]
+ci-dependency-report = [{ name = "packaging", specifier = "==26.2" }]
+ci-security = [
+    { name = "pip-audit", specifier = "==2.10.1" },
+    { name = "zizmor", specifier = "==1.28.0" },
+]
 dev = [
     { name = "basedpyright", specifier = "==1.39.9" },
     { name = "captum", specifier = "==0.9.0" },
@@ -1516,4 +1908,22 @@ explainability = [
     { name = "captum", specifier = "==0.9.0" },
     { name = "matplotlib", specifier = "==3.11.0" },
     { name = "pillow", specifier = "==12.3.0" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/92/6b58872ac1184a441037bdc05c658a3900f49401b25f6e834a268ef6ff52/zizmor-1.28.0.tar.gz", hash = "sha256:6d5a300b80bf4c12e9cbe78ffd3874ec3f94b65bea78c994ec18157e2846ece0", size = 550169, upload-time = "2026-07-21T22:16:27.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/48/a725a1c34e5565eeeb4e4a93c59662f206e5156f2029627c66b2373edf55/zizmor-1.28.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:149dba59a8bd2897960ee54c40ae8b5801a71293bad71c8d2913c74ab66a294c", size = 8909502, upload-time = "2026-07-21T22:16:07.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/ba6d0eb2b336b4c4826bb0c9ed23c3239d46d71d8c1ddd2d395efeff7f52/zizmor-1.28.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0949f57a6d20deeb9c509705afce8de233c166475e25be305985a1fe553c6e0d", size = 8520554, upload-time = "2026-07-21T22:16:09.587Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/07/69aba8157056fc0949cbdc787d8437813961e204a117c629d34afc827d6d/zizmor-1.28.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:9819f91f0ef486e4af98a6aacfed23c6b4067fabcecb88d49231228a3d43f821", size = 8759226, upload-time = "2026-07-21T22:16:11.627Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/b65717a3ca4573611f47612e67be5458ff700e857f49f759741fa67b0519/zizmor-1.28.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:354e6cb98a15a88593a6f7ac6236b092b83a2aad5c4768ee750f9b3262f668d9", size = 8382005, upload-time = "2026-07-21T22:16:13.896Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b4/f823bd2a1ba6dc432fdcbd249d4c442ce79bd137d34d986fce5c181f2800/zizmor-1.28.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ae2cab67ce713e760e0d1b61ad749d374693ea2b310337aab11cd446748267f3", size = 9175601, upload-time = "2026-07-21T22:16:16.177Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/adad17b0320eb3bc9ed797019fccf69a809affdf5ba9402bdc8b910957e1/zizmor-1.28.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7b00018cf2cc948c3b3e010c1a1f30fdc001f0d062640469f17e0ef006e74eb7", size = 8792861, upload-time = "2026-07-21T22:16:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/3d/4d5583f24730f404c104eacf8aca4ca5a3d4c480e9d3cfe3eadd93351fd6/zizmor-1.28.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6897f02b0d02fd709f5ebc13cd37d97ad464219e0ba86a03f6d86f7777b7b102", size = 8343070, upload-time = "2026-07-21T22:16:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e2/4521e6dd56bc0d44eefb177794e261925c5cd00ab647b17e5513bddcb985/zizmor-1.28.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ef69d198dcf6835c9b6eea8673cbc5c36f10b3f1b98b51d28266b7e01c3704d4", size = 9262222, upload-time = "2026-07-21T22:16:21.89Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/5d841d197c821921cb8243352c610ca2505a86871c10f81efe4da190d24c/zizmor-1.28.0-py3-none-win32.whl", hash = "sha256:833c360ba5a9c74ca45007b8c79939826fca0c5ed65144fa08f63a7009cef096", size = 7541161, upload-time = "2026-07-21T22:16:23.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f5/3f4591746e5a9c7e8efc2e9e02aa43e1aa0957fe33cae64ce386c74b882e/zizmor-1.28.0-py3-none-win_amd64.whl", hash = "sha256:c93b30d211b0b0c38905a8803cc2653fff37de03eb77105302a02f709773bd4a", size = 8619340, upload-time = "2026-07-21T22:16:25.6Z" },
 ]


### PR DESCRIPTION
## Summary

- add required GitHub Actions CPU validation on Python 3.11 and 3.14 with explicit PyTorch 2.13.0 and TorchAO 0.17.0 assertions
- add locked dependency-health reporting and a manual production-build validation harness
- add a real CPU torch.compile checkpointing regression and preserve CircleCI/Codecov for the overlap phase

## Validation

- actionlint 1.7.12 against all workflows
- make audit-workflows
- make audit-dependencies PYTHON_VERSION=3.11
- make audit-dependencies PYTHON_VERSION=3.14
- make report-deprecations
- make quality
- make types
- make test-ci
- make test-compile-cpu
- make test-deprecations
- make check-distribution
- make check
- clean-install smoke tests for source and sdist-rebuilt wheels on Python 3.11 and 3.14

## Rollout

This is phase 1 of the approved migration. CircleCI and Codecov remain active until the GitHub checks and the default-branch production dispatch are proven. CUDA remains deferred.