### PR TITLE
Support routed cross-attention masks

### DIFF
--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -495,6 +495,45 @@ class TestCrossAttentionTransformer:
         y = layer(x, kv)
         assert_close(y, x)
 
+    def test_cross_attention_mask_tracks_stochastic_depth_batch_subset(self, device, monkeypatch):
+        batch_size, query_length, hidden_size, context_length = 8, 12, 64, 6
+        drop_path_rate = 0.5
+        expected_keep_count = _expected_keep_count(batch_size, drop_path_rate)
+        layer = CrossAttentionTransformer(
+            hidden_size=hidden_size,
+            ffn_hidden_size=hidden_size * 2,
+            num_attention_heads=4,
+            hidden_dropout=0.0,
+            attention_dropout=0.0,
+            drop_path_rate=drop_path_rate,
+        ).to(device)
+        layer.train()
+
+        observed_mask_shapes: list[tuple[int, ...]] = []
+        original_cross_attention_forward = layer.cross_attention.forward
+
+        def record_cross_attention_mask(
+            q: torch.Tensor,
+            kv: torch.Tensor,
+            attn_mask: torch.Tensor | None = None,
+            rope_q: torch.Tensor | None = None,
+            rope_k: torch.Tensor | None = None,
+        ) -> torch.Tensor:
+            assert attn_mask is not None
+            observed_mask_shapes.append(tuple(attn_mask.shape))
+            return original_cross_attention_forward(q, kv, attn_mask=attn_mask, rope_q=rope_q, rope_k=rope_k)
+
+        monkeypatch.setattr(layer.cross_attention, "forward", record_cross_attention_mask)
+
+        x = torch.randn(batch_size, query_length, hidden_size, device=device)
+        kv = torch.randn(batch_size, context_length, hidden_size, device=device)
+        attention_mask = torch.ones(batch_size, 1, query_length, context_length, dtype=torch.bool, device=device)
+
+        output = layer(x, kv, attn_mask=attention_mask)
+
+        assert output.shape == x.shape
+        assert observed_mask_shapes == [(expected_keep_count, 1, query_length, context_length)]
+
     @pytest.mark.parametrize(
         ("norm_type", "norm_cls"), [("rmsnorm", torch.nn.RMSNorm), ("layernorm", torch.nn.LayerNorm)]
     )

--- a/vit/transformer.py
+++ b/vit/transformer.py
@@ -509,15 +509,23 @@ class CrossAttentionTransformer(nn.Module):
         rope_q: Tensor | None = None,
         rope_k: Tensor | None = None,
         conditioning: Tensor | None = None,
+        attn_mask: Tensor | None = None,
     ) -> Tensor:
         batch_size = x.shape[0]
 
         x_residual, keep_indices, residual_scale = _select_residual_subset(x, self.drop_path_rate, self.training)
         kv_residual = _subset_batch(kv, keep_indices, batch_size)
+        attn_mask_residual = _subset_batch(attn_mask, keep_indices, batch_size) if attn_mask is not None else None
         rope_q_residual = _subset_batched_rope(rope_q, keep_indices, batch_size)
         rope_k_residual = _subset_batched_rope(rope_k, keep_indices, batch_size)
         o = self.layer_scale_cross(
-            self.cross_attention(x_residual, kv_residual, rope_q=rope_q_residual, rope_k=rope_k_residual)
+            self.cross_attention(
+                x_residual,
+                kv_residual,
+                attn_mask=attn_mask_residual,
+                rope_q=rope_q_residual,
+                rope_k=rope_k_residual,
+            )
         )
         x = _merge_residual_subset(x, o, keep_indices, residual_scale)
 
@@ -535,5 +543,6 @@ class CrossAttentionTransformer(nn.Module):
             rope_q: Tensor | None = None,
             rope_k: Tensor | None = None,
             conditioning: Tensor | None = None,
+            attn_mask: Tensor | None = None,
         ) -> Tensor:
-            return self.forward(x, kv, rope_q, rope_k, conditioning)
+            return self.forward(x, kv, rope_q, rope_k, conditioning, attn_mask)


### PR DESCRIPTION
## Motivation

The CLS predictor routing experiments need query-specific masks on cross-attention while preserving selective stochastic-depth alignment. Without forwarding and subsetting the mask, routed predictor queries can see disallowed context or fail on a batch-shape mismatch.

## Solution

Accept an optional cross-attention mask in `CrossAttentionTransformer`, subset it with the same retained batch indices as the queries and key/value context, and forward it to the cross-attention layer.

## Changes

- add optional `attn_mask` support to `CrossAttentionTransformer.forward` and checkpointed forwarding
- subset batch-shaped masks when stochastic depth keeps only part of a batch
- add a regression test that verifies mask/query alignment under selective stochastic depth

## Test plan

- [x] `uv run pytest -q tests/test_transformer.py` (99 passed)
- [x] `make check`
- [x] `make test-ci` (603 passed, 3 skipped, 295 deselected)

Generated with Codex