### PR TITLE
Add configurable global and visual token pathways

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ Main flow is `Images -> PatchEmbed -> Transformer -> ViTFeatures -> Heads`.
 - CLS and register tokens are optional. Pooling and classification behavior remains explicit in heads.
 - Prefer config-driven construction via `ViTConfig.instantiate()` and `HeadConfig.instantiate()`.
 - Use `activation_checkpointing=True` in `ViTConfig` when trading latency for lower training memory.
-- Token specialization treats the leading CLS and register tokens as one global stream. When enabled, split the
-  pre-attention and pre-MLP norms plus LayerScale in every encoder block, and split QKV only in the configured leading
-  block count. Clone each visual branch from its global branch so specialized and shared models are identical at
-  initialization; keep attention, output projections, MLP projections, and the final output norm shared.
+- Token specialization is disabled by default and does not change the `ViT.forward()` or `ViTFeatures` contracts.
+  When enabled, treat the leading CLS and register tokens as one global stream. Split the pre-attention and pre-MLP
+  norms, plus configured LayerScale parameters, in every encoder block. Split QKV only in the configured leading block
+  count. Clone each visual branch from its global branch so specialized and shared models are identical at
+  initialization. Keep attention, output projections, MLP projections, and the final output norm shared.
 
 ### Explainability architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ Main flow is `Images -> PatchEmbed -> Transformer -> ViTFeatures -> Heads`.
 - CLS and register tokens are optional. Pooling and classification behavior remains explicit in heads.
 - Prefer config-driven construction via `ViTConfig.instantiate()` and `HeadConfig.instantiate()`.
 - Use `activation_checkpointing=True` in `ViTConfig` when trading latency for lower training memory.
+- Token specialization treats the leading CLS and register tokens as one global stream. When enabled, split the
+  pre-attention and pre-MLP norms plus LayerScale in every encoder block, and split QKV only in the configured leading
+  block count. Clone each visual branch from its global branch so specialized and shared models are identical at
+  initialization; keep attention, output projections, MLP projections, and the final output norm shared.
 
 ### Explainability architecture
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ features = model(x)
 logits = model.heads["cls"](features.visual_tokens)  # B, 10
 ```
 
+### Global and visual token pathways
+
+By default, CLS, register, and visual tokens share every encoder parameter. Token specialization can give the
+CLS/register prefix and visual tokens separate normalization parameters, plus separate LayerScale parameters when
+LayerScale is configured. Attention still connects every token. A configurable number of leading blocks can also use
+separate QKV projections:
+
+```python
+config = ViTConfig(
+    # ... other parameters ...
+    depth=12,
+    num_cls_tokens=1,
+    num_register_tokens=7,
+    specialize_global_token_norms=True,
+    specialize_global_token_qkv_blocks=4,
+)
+model = config.instantiate()
+features = model(x)  # ViTFeatures, unchanged from the shared-path model
+```
+
+Both specialization options default to disabled. Specialized parameters are cloned from their shared counterparts at
+initialization, so enabling the feature does not change the initial function before the paths receive separate updates.
+
 ## CUDA GLU GEMM Autotuning
 
 Compiled GLU MLPs can opt into PyTorch Inductor GEMM autotuning when steady-state CUDA throughput is more important

--- a/tests/test_explain_trace.py
+++ b/tests/test_explain_trace.py
@@ -94,6 +94,33 @@ def test_trace_matches_eval_forward_and_preserves_full_visual_layout() -> None:
     assert trace.layers[0].attention_probabilities.requires_grad
 
 
+def test_trace_matches_diverged_specialized_attention_and_retains_visual_gradients() -> None:
+    torch.manual_seed(37)
+    model = ViT(
+        make_tiny_config(
+            depth=1,
+            specialize_global_token_norms=True,
+            specialize_global_token_qkv_blocks=1,
+        )
+    ).eval()
+    attention = model.get_block(0).self_attention
+    assert attention.visual_norm is not None
+    assert attention.visual_qkv_proj is not None
+    with torch.no_grad():
+        attention.visual_norm.weight.mul_(2.0)
+        attention.visual_qkv_proj.weight.add_(0.5)
+        attention.out_proj.weight.normal_(std=0.1)
+    inputs = torch.randn(2, 3, 9, 10)
+
+    expected = model(inputs)
+    trace = ViTExplainer(model, output_fn).trace(inputs, config=TraceConfig(retain_gradients=True))
+
+    assert_close(trace.features.dense_features, expected.dense_features)
+    trace.features.dense_features.square().mean().backward()
+    assert attention.visual_norm.weight.grad is not None
+    assert attention.visual_qkv_proj.weight.grad is not None
+
+
 def test_trace_restores_model_and_existing_gradients() -> None:
     model = ViT(make_tiny_config()).train()
     inputs = torch.randn(1, 3, 9, 10, requires_grad=True)

--- a/tests/test_token_specialization.py
+++ b/tests/test_token_specialization.py
@@ -3,12 +3,14 @@ import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
 import torch
 from torch.testing import assert_close
+from torchao.quantization import Int8Tensor, Int8WeightOnlyConfig
 
-from vit import ViT, ViTConfig
+from vit import ViT, ViTConfig, ViTFeatures
 from vit.layer_scale import LayerScale
 from vit.transformer import TransformerEncoderLayer
 
@@ -21,7 +23,13 @@ NUM_GLOBAL_TOKENS = NUM_CLS_TOKENS + NUM_REGISTER_TOKENS
 DEPTH = 3
 QKV_SPECIALIZATION_BLOCKS = 1
 TEST_PROJECTION_STD = 0.02
-COMPILE_TEST_TIMEOUT_SECONDS = 120
+COMPILE_TEST_TIMEOUT_SECONDS = 240
+TORCHAO_QUANTIZATION_CONFIG_VERSION = 2
+LEGACY_DROPOUT = 0.1
+LAYER_SCALE_INIT = 1e-5
+LEGACY_POSITION_ENCODING = "fourier"
+MODEL_INITIALIZATION_SEED = 7
+RESIDUAL_INITIALIZATION_SEED = 11
 
 
 def _config(**overrides: object) -> ViTConfig:
@@ -39,7 +47,7 @@ def _config(**overrides: object) -> ViTConfig:
         "num_cls_tokens": NUM_CLS_TOKENS,
         "num_register_tokens": NUM_REGISTER_TOKENS,
         "pos_enc": "rope",
-        "layer_scale": 1e-5,
+        "layer_scale": LAYER_SCALE_INIT,
         "norm_type": "layernorm",
         "dtype": torch.float32,
     }
@@ -54,18 +62,143 @@ def _specialized_config() -> ViTConfig:
     )
 
 
-def test_specialization_requires_global_tokens() -> None:
+@torch.no_grad()
+def _seed_residual_outputs(model: ViT) -> None:
+    for block in model.blocks:
+        assert isinstance(block, TransformerEncoderLayer)
+        torch.nn.init.normal_(block.self_attention.out_proj.weight, std=TEST_PROJECTION_STD)
+        torch.nn.init.normal_(block.mlp.fc2.weight, std=TEST_PROJECTION_STD)
+
+
+def test_specialization_is_disabled_by_default() -> None:
+    config = _config()
+    model = ViT(config)
+
+    assert config.specialize_global_token_norms is False
+    assert config.specialize_global_token_qkv_blocks == 0
+    assert config.token_specialization_enabled is False
+    assert config.num_global_tokens == NUM_GLOBAL_TOKENS
+    assert all("visual_" not in name for name in model.state_dict())
+
+
+def test_default_config_preserves_encoder_factory_call_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_factory = ViT.create_encoder_layer
+    factory_calls = 0
+
+    def legacy_factory(
+        self: ViT,
+        mlp_quantization_config: Any | None = None,
+        qkv_quantization_config: Any | None = None,
+        attn_quantization_config: Any | None = None,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> TransformerEncoderLayer:
+        nonlocal factory_calls
+        factory_calls += 1
+        return original_factory(
+            self,
+            mlp_quantization_config,
+            qkv_quantization_config,
+            attn_quantization_config,
+            device,
+            dtype,
+        )
+
+    monkeypatch.setattr(ViT, "create_encoder_layer", legacy_factory)
+
+    model = ViT(_config())
+
+    assert len(model.blocks) == DEPTH
+    assert factory_calls == DEPTH
+
+
+def test_new_config_options_do_not_shift_legacy_positional_arguments() -> None:
+    config = ViTConfig(
+        3,
+        (4, 4),
+        (8, 8),
+        DEPTH,
+        HIDDEN_SIZE,
+        HIDDEN_SIZE * 2,
+        NUM_HEADS,
+        LEGACY_DROPOUT,
+        LEGACY_DROPOUT,
+        True,
+        True,
+        "srelu",
+        0.0,
+        NUM_REGISTER_TOKENS,
+        NUM_CLS_TOKENS,
+        LEGACY_POSITION_ENCODING,
+    )
+
+    assert config.pos_enc == LEGACY_POSITION_ENCODING
+    assert config.specialize_global_token_norms is False
+    assert config.specialize_global_token_qkv_blocks == 0
+
+
+def test_layer_scale_preserves_legacy_positional_factory_arguments() -> None:
+    layer_scale = LayerScale(
+        HIDDEN_SIZE,
+        LAYER_SCALE_INIT,
+        False,
+        torch.device("cpu"),
+        torch.float64,
+    )
+
+    assert layer_scale.gamma.dtype == torch.float64
+    assert layer_scale.visual_gamma is None
+
+
+@pytest.mark.parametrize(
+    "specialization",
+    [
+        {"specialize_global_token_norms": True},
+        {"specialize_global_token_qkv_blocks": 1},
+    ],
+)
+def test_specialization_requires_global_tokens(specialization: dict[str, object]) -> None:
     with pytest.raises(ValueError, match="at least one CLS or register token"):
         _config(
             num_cls_tokens=0,
             num_register_tokens=0,
-            specialize_global_token_norms=True,
+            **specialization,
         )
 
 
-def test_qkv_specialization_depth_must_fit_backbone() -> None:
-    with pytest.raises(ValueError, match="cannot exceed depth"):
-        replace(_specialized_config(), specialize_global_token_qkv_blocks=DEPTH + 1)
+@pytest.mark.parametrize("qkv_blocks", [-1, DEPTH + 1])
+def test_qkv_specialization_depth_must_fit_backbone(qkv_blocks: int) -> None:
+    with pytest.raises(ValueError, match="must be non-negative|cannot exceed depth"):
+        replace(_specialized_config(), specialize_global_token_qkv_blocks=qkv_blocks)
+
+
+def test_specialization_config_round_trips_through_yaml() -> None:
+    restored = ViTConfig.from_yaml(_specialized_config().to_yaml())
+
+    assert restored.specialize_global_token_norms is True
+    assert restored.specialize_global_token_qkv_blocks == QKV_SPECIALIZATION_BLOCKS
+    assert restored.token_specialization_enabled is True
+
+
+def test_norm_and_qkv_specialization_can_be_configured_independently() -> None:
+    norms_only = ViT(_config(specialize_global_token_norms=True))
+    qkv_only = ViT(_config(specialize_global_token_qkv_blocks=QKV_SPECIALIZATION_BLOCKS))
+
+    for block in norms_only.blocks:
+        assert isinstance(block, TransformerEncoderLayer)
+        assert block.self_attention.visual_norm is not None
+        assert block.self_attention.visual_qkv_proj is None
+        assert block.mlp.visual_norm is not None
+    for block_index, block in enumerate(qkv_only.blocks):
+        assert isinstance(block, TransformerEncoderLayer)
+        assert block.self_attention.visual_norm is None
+        assert (block.self_attention.visual_qkv_proj is not None) is (block_index < QKV_SPECIALIZATION_BLOCKS)
+        assert block.mlp.visual_norm is None
+
+
+def test_norm_specialization_rejects_conditioned_mlp() -> None:
+    with pytest.raises(ValueError, match="incompatible with conditioned MLPs"):
+        _config(specialize_global_token_norms=True, conditioning_size=HIDDEN_SIZE)
 
 
 def test_specialization_clones_norms_scales_and_early_qkv() -> None:
@@ -93,17 +226,55 @@ def test_specialization_clones_norms_scales_and_early_qkv() -> None:
             assert attention.visual_qkv_proj is None
 
 
-def test_specialization_is_functionally_identical_at_initialization() -> None:
-    torch.manual_seed(7)
-    baseline = ViT(_config()).eval()
-    torch.manual_seed(7)
-    specialized = ViT(_specialized_config()).eval()
+@pytest.mark.parametrize(
+    "specialization",
+    [
+        {"specialize_global_token_norms": True},
+        {"specialize_global_token_qkv_blocks": QKV_SPECIALIZATION_BLOCKS},
+        {
+            "specialize_global_token_norms": True,
+            "specialize_global_token_qkv_blocks": QKV_SPECIALIZATION_BLOCKS,
+        },
+    ],
+    ids=["norms", "qkv", "norms-and-qkv"],
+)
+@pytest.mark.parametrize("activation", ["srelu", "swiglu"])
+@pytest.mark.parametrize("norm_type", ["rmsnorm", "layernorm"])
+def test_specialization_is_functionally_identical_at_initialization(
+    specialization: dict[str, object],
+    activation: str,
+    norm_type: str,
+) -> None:
+    baseline_config = _config(activation=activation, norm_type=norm_type)
+    specialized_config = replace(baseline_config, **specialization)
+    torch.manual_seed(MODEL_INITIALIZATION_SEED)
+    baseline = ViT(baseline_config).eval()
+    torch.manual_seed(MODEL_INITIALIZATION_SEED)
+    specialized = ViT(specialized_config).eval()
+    torch.manual_seed(RESIDUAL_INITIALIZATION_SEED)
+    _seed_residual_outputs(baseline)
+    torch.manual_seed(RESIDUAL_INITIALIZATION_SEED)
+    _seed_residual_outputs(specialized)
     images = torch.randn(2, 3, 8, 8)
 
     baseline_features = baseline(images)
     specialized_features = specialized(images)
 
     assert_close(specialized_features.dense_features, baseline_features.dense_features)
+
+
+def test_specialization_preserves_forward_output_contract_with_masking() -> None:
+    model = ViT(_specialized_config()).eval()
+    images = torch.randn(2, 3, 8, 8)
+    mask = torch.tensor([[True, False, True, False], [False, True, False, True]])
+
+    features = model(images, mask=mask)
+
+    assert isinstance(features, ViTFeatures)
+    assert features.cls_tokens.shape == (2, NUM_CLS_TOKENS, HIDDEN_SIZE)
+    assert features.register_tokens.shape == (2, NUM_REGISTER_TOKENS, HIDDEN_SIZE)
+    assert features.visual_tokens.shape == (2, 2, HIDDEN_SIZE)
+    assert features.tokenized_size == (2, 2)
 
 
 def test_specialized_paths_receive_distinct_gradients() -> None:
@@ -125,6 +296,33 @@ def test_specialized_paths_receive_distinct_gradients() -> None:
     assert attention.visual_qkv_proj is not None
     assert attention.visual_qkv_proj.weight.grad is not None
     assert not torch.equal(attention.qkv_proj.weight.grad, attention.visual_qkv_proj.weight.grad)
+
+
+def test_specialized_paths_support_activation_checkpointing() -> None:
+    model = ViT(replace(_specialized_config(), activation_checkpointing=True)).train()
+    _seed_residual_outputs(model)
+    images = torch.randn(2, 3, 8, 8, requires_grad=True)
+
+    model(images).dense_features.square().mean().backward()
+
+    first_block = model.get_block(0)
+    assert first_block.self_attention.visual_norm is not None
+    assert first_block.self_attention.visual_norm.weight.grad is not None
+    assert first_block.self_attention.visual_qkv_proj is not None
+    assert first_block.self_attention.visual_qkv_proj.weight.grad is not None
+    assert first_block.mlp.visual_norm is not None
+    assert first_block.mlp.visual_norm.weight.grad is not None
+
+
+def test_qkv_specialization_quantizes_both_projection_paths() -> None:
+    quantization = Int8WeightOnlyConfig(version=TORCHAO_QUANTIZATION_CONFIG_VERSION)
+    model = ViT(_specialized_config(), qkv_quantization_config=quantization).eval()
+    first_attention = model.get_block(0).self_attention
+
+    assert isinstance(first_attention.qkv_proj.weight, Int8Tensor)
+    assert first_attention.visual_qkv_proj is not None
+    assert isinstance(first_attention.visual_qkv_proj.weight, Int8Tensor)
+    assert model(torch.randn(2, 3, 8, 8)).dense_features.shape == (2, NUM_GLOBAL_TOKENS + 4, HIDDEN_SIZE)
 
 
 def test_attention_weight_tracing_supports_specialized_paths() -> None:

--- a/tests/test_token_specialization.py
+++ b/tests/test_token_specialization.py
@@ -1,4 +1,8 @@
+import os
+import subprocess
+import sys
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 import torch
@@ -17,6 +21,7 @@ NUM_GLOBAL_TOKENS = NUM_CLS_TOKENS + NUM_REGISTER_TOKENS
 DEPTH = 3
 QKV_SPECIALIZATION_BLOCKS = 1
 TEST_PROJECTION_STD = 0.02
+COMPILE_TEST_TIMEOUT_SECONDS = 120
 
 
 def _config(**overrides: object) -> ViTConfig:
@@ -130,3 +135,18 @@ def test_attention_weight_tracing_supports_specialized_paths() -> None:
 
     assert tuple(weights) == tuple(f"layer_{index}" for index in range(DEPTH))
     assert weights["layer_0"].shape[:3] == (2, NUM_HEADS, NUM_GLOBAL_TOKENS + 4)
+
+
+@pytest.mark.compile
+@pytest.mark.cuda
+def test_specialized_attention_backward_compiles_for_masked_sequence() -> None:
+    environment = os.environ.copy()
+    environment.pop("TORCHDYNAMO_DISABLE", None)
+    check_script = Path(__file__).with_name("token_specialized_attention_compile_check.py")
+
+    subprocess.run(
+        [sys.executable, str(check_script)],
+        check=True,
+        env=environment,
+        timeout=COMPILE_TEST_TIMEOUT_SECONDS,
+    )

--- a/tests/test_token_specialization.py
+++ b/tests/test_token_specialization.py
@@ -1,0 +1,132 @@
+from dataclasses import replace
+
+import pytest
+import torch
+from torch.testing import assert_close
+
+from vit import ViT, ViTConfig
+from vit.layer_scale import LayerScale
+from vit.transformer import TransformerEncoderLayer
+
+
+HIDDEN_SIZE = 32
+NUM_HEADS = 4
+NUM_CLS_TOKENS = 1
+NUM_REGISTER_TOKENS = 2
+NUM_GLOBAL_TOKENS = NUM_CLS_TOKENS + NUM_REGISTER_TOKENS
+DEPTH = 3
+QKV_SPECIALIZATION_BLOCKS = 1
+TEST_PROJECTION_STD = 0.02
+
+
+def _config(**overrides: object) -> ViTConfig:
+    values: dict[str, object] = {
+        "in_channels": 3,
+        "patch_size": (4, 4),
+        "img_size": (8, 8),
+        "depth": DEPTH,
+        "hidden_size": HIDDEN_SIZE,
+        "ffn_hidden_size": HIDDEN_SIZE * 2,
+        "num_attention_heads": NUM_HEADS,
+        "hidden_dropout": 0.0,
+        "attention_dropout": 0.0,
+        "drop_path_rate": 0.0,
+        "num_cls_tokens": NUM_CLS_TOKENS,
+        "num_register_tokens": NUM_REGISTER_TOKENS,
+        "pos_enc": "rope",
+        "layer_scale": 1e-5,
+        "norm_type": "layernorm",
+        "dtype": torch.float32,
+    }
+    values.update(overrides)
+    return ViTConfig(**values)  # type: ignore[arg-type]
+
+
+def _specialized_config() -> ViTConfig:
+    return _config(
+        specialize_global_token_norms=True,
+        specialize_global_token_qkv_blocks=QKV_SPECIALIZATION_BLOCKS,
+    )
+
+
+def test_specialization_requires_global_tokens() -> None:
+    with pytest.raises(ValueError, match="at least one CLS or register token"):
+        _config(
+            num_cls_tokens=0,
+            num_register_tokens=0,
+            specialize_global_token_norms=True,
+        )
+
+
+def test_qkv_specialization_depth_must_fit_backbone() -> None:
+    with pytest.raises(ValueError, match="cannot exceed depth"):
+        replace(_specialized_config(), specialize_global_token_qkv_blocks=DEPTH + 1)
+
+
+def test_specialization_clones_norms_scales_and_early_qkv() -> None:
+    model = ViT(_specialized_config())
+
+    for block_index, block in enumerate(model.blocks):
+        assert isinstance(block, TransformerEncoderLayer)
+        assert isinstance(block.layer_scale_attn, LayerScale)
+        assert isinstance(block.layer_scale_mlp, LayerScale)
+        attention = block.self_attention
+        assert attention.num_global_tokens == NUM_GLOBAL_TOKENS
+        assert attention.visual_norm is not None
+        assert_close(attention.visual_norm.weight, attention.norm.weight)
+        assert block.mlp.visual_norm is not None
+        assert_close(block.mlp.visual_norm.weight, block.mlp.norm.weight)
+        assert block.layer_scale_attn.visual_gamma is not None
+        assert_close(block.layer_scale_attn.visual_gamma, block.layer_scale_attn.gamma)
+        assert block.layer_scale_mlp.visual_gamma is not None
+        assert_close(block.layer_scale_mlp.visual_gamma, block.layer_scale_mlp.gamma)
+
+        if block_index < QKV_SPECIALIZATION_BLOCKS:
+            assert attention.visual_qkv_proj is not None
+            assert_close(attention.visual_qkv_proj.weight, attention.qkv_proj.weight)
+        else:
+            assert attention.visual_qkv_proj is None
+
+
+def test_specialization_is_functionally_identical_at_initialization() -> None:
+    torch.manual_seed(7)
+    baseline = ViT(_config()).eval()
+    torch.manual_seed(7)
+    specialized = ViT(_specialized_config()).eval()
+    images = torch.randn(2, 3, 8, 8)
+
+    baseline_features = baseline(images)
+    specialized_features = specialized(images)
+
+    assert_close(specialized_features.dense_features, baseline_features.dense_features)
+
+
+def test_specialized_paths_receive_distinct_gradients() -> None:
+    model = ViT(_specialized_config())
+    first_block = model.get_block(0)
+    torch.nn.init.normal_(first_block.self_attention.out_proj.weight, std=TEST_PROJECTION_STD)
+    images = torch.randn(2, 3, 8, 8)
+
+    features = model(images)
+    loss = features.cls_tokens.square().mean() + 2.0 * features.visual_tokens.square().mean()
+    loss.backward()
+
+    attention = first_block.self_attention
+    assert attention.norm.weight.grad is not None
+    assert attention.visual_norm is not None
+    assert attention.visual_norm.weight.grad is not None
+    assert not torch.equal(attention.norm.weight.grad, attention.visual_norm.weight.grad)
+    assert attention.qkv_proj.weight.grad is not None
+    assert attention.visual_qkv_proj is not None
+    assert attention.visual_qkv_proj.weight.grad is not None
+    assert not torch.equal(attention.qkv_proj.weight.grad, attention.visual_qkv_proj.weight.grad)
+
+
+def test_attention_weight_tracing_supports_specialized_paths() -> None:
+    model = ViT(_specialized_config()).eval()
+    images = torch.randn(2, 3, 8, 8)
+
+    weights = model.forward_attention_weights(images)
+
+    assert tuple(weights) == tuple(f"layer_{index}" for index in range(DEPTH))
+    assert weights["layer_0"].shape[:3] == (2, NUM_HEADS, NUM_GLOBAL_TOKENS + 4)

--- a/tests/token_specialized_attention_compile_check.py
+++ b/tests/token_specialized_attention_compile_check.py
@@ -20,9 +20,12 @@ ATTENTION_DROPOUT = 0.1
 PROJECTION_DROPOUT = 0.1
 
 
-def main() -> None:
-    assert torch._dynamo.config.disable is False
-    assert hasattr(attention_token_specialized_qkv_packed, "_torchdynamo_orig_callable")
+def _assert_finite_gradient(tensor: torch.Tensor) -> None:
+    assert tensor.grad is not None
+    assert torch.isfinite(tensor.grad).all()
+
+
+def _run_case(*, separate_norms: bool, separate_qkv: bool) -> None:
     sequence_length = NUM_GLOBAL_TOKENS + NUM_MASKED_VISUAL_TOKENS
     features = torch.randn(BATCH_SIZE, sequence_length, HIDDEN_SIZE, device="cuda", requires_grad=True)
     with torch.inference_mode():
@@ -34,9 +37,11 @@ def main() -> None:
         )
     qkv_output_size = 3 * HIDDEN_SIZE
     global_qkv_weight = torch.randn(qkv_output_size, HIDDEN_SIZE, device="cuda", requires_grad=True)
-    visual_qkv_weight = global_qkv_weight
+    visual_qkv_weight = (
+        torch.randn(qkv_output_size, HIDDEN_SIZE, device="cuda", requires_grad=True) if separate_qkv else None
+    )
     global_norm_weight = torch.ones(HIDDEN_SIZE, device="cuda", requires_grad=True)
-    visual_norm_weight = torch.ones(HIDDEN_SIZE, device="cuda", requires_grad=True)
+    visual_norm_weight = torch.ones(HIDDEN_SIZE, device="cuda", requires_grad=True) if separate_norms else None
     out_weight = torch.randn(HIDDEN_SIZE, HIDDEN_SIZE, device="cuda", requires_grad=True)
     head_size = HIDDEN_SIZE // NUM_HEADS
     q_norm_weight = torch.ones(head_size, device="cuda", requires_grad=True)
@@ -89,8 +94,30 @@ def main() -> None:
         output = run_attention(features, masked_rope, training=True)
     output.square().mean().backward()
 
-    assert global_qkv_weight.grad is not None
-    assert torch.isfinite(global_qkv_weight.grad).all()
+    parameters = [
+        features,
+        global_qkv_weight,
+        global_norm_weight,
+        out_weight,
+        q_norm_weight,
+        k_norm_weight,
+    ]
+    if separate_norms:
+        assert visual_norm_weight is not None
+        parameters.append(visual_norm_weight)
+    for parameter in parameters:
+        _assert_finite_gradient(parameter)
+    if separate_qkv:
+        assert visual_qkv_weight is not None
+        _assert_finite_gradient(visual_qkv_weight)
+
+
+def main() -> None:
+    assert torch._dynamo.config.disable is False
+    assert hasattr(attention_token_specialized_qkv_packed, "_torchdynamo_orig_callable")
+    _run_case(separate_norms=True, separate_qkv=False)
+    _run_case(separate_norms=False, separate_qkv=True)
+    _run_case(separate_norms=True, separate_qkv=True)
 
 
 if __name__ == "__main__":

--- a/tests/token_specialized_attention_compile_check.py
+++ b/tests/token_specialized_attention_compile_check.py
@@ -1,0 +1,97 @@
+"""Isolated CUDA regression check for token-specialized compiled attention."""
+
+import torch
+import torch._dynamo
+
+from vit.attention import attention_token_specialized_qkv_packed
+
+
+IMAGE_SIZE = 32
+PATCH_SIZE = 4
+HIDDEN_SIZE = 384
+NUM_HEADS = 12
+NUM_CLS_TOKENS = 1
+NUM_REGISTER_TOKENS = 7
+NUM_GLOBAL_TOKENS = NUM_CLS_TOKENS + NUM_REGISTER_TOKENS
+NUM_VISUAL_TOKENS = (IMAGE_SIZE // PATCH_SIZE) ** 2
+NUM_MASKED_VISUAL_TOKENS = NUM_VISUAL_TOKENS // 2
+BATCH_SIZE = 2
+ATTENTION_DROPOUT = 0.1
+PROJECTION_DROPOUT = 0.1
+
+
+def main() -> None:
+    assert torch._dynamo.config.disable is False
+    assert hasattr(attention_token_specialized_qkv_packed, "_torchdynamo_orig_callable")
+    sequence_length = NUM_GLOBAL_TOKENS + NUM_MASKED_VISUAL_TOKENS
+    features = torch.randn(BATCH_SIZE, sequence_length, HIDDEN_SIZE, device="cuda", requires_grad=True)
+    with torch.inference_mode():
+        full_features = torch.randn(
+            BATCH_SIZE,
+            NUM_GLOBAL_TOKENS + NUM_VISUAL_TOKENS,
+            HIDDEN_SIZE,
+            device="cuda",
+        )
+    qkv_output_size = 3 * HIDDEN_SIZE
+    global_qkv_weight = torch.randn(qkv_output_size, HIDDEN_SIZE, device="cuda", requires_grad=True)
+    visual_qkv_weight = global_qkv_weight
+    global_norm_weight = torch.ones(HIDDEN_SIZE, device="cuda", requires_grad=True)
+    visual_norm_weight = torch.ones(HIDDEN_SIZE, device="cuda", requires_grad=True)
+    out_weight = torch.randn(HIDDEN_SIZE, HIDDEN_SIZE, device="cuda", requires_grad=True)
+    head_size = HIDDEN_SIZE // NUM_HEADS
+    q_norm_weight = torch.ones(head_size, device="cuda", requires_grad=True)
+    k_norm_weight = torch.ones(head_size, device="cuda", requires_grad=True)
+    with torch.inference_mode():
+        full_rope = torch.randn(2, NUM_VISUAL_TOKENS, head_size, device="cuda")
+    masked_rope = torch.randn(
+        2,
+        BATCH_SIZE,
+        1,
+        NUM_MASKED_VISUAL_TOKENS,
+        head_size,
+        device="cuda",
+    )
+
+    def run_attention(input_features: torch.Tensor, rope: torch.Tensor, *, training: bool) -> torch.Tensor:
+        return attention_token_specialized_qkv_packed(
+            input_features,
+            NUM_GLOBAL_TOKENS,
+            global_qkv_weight,
+            None,
+            visual_qkv_weight,
+            None,
+            global_norm_weight,
+            None,
+            visual_norm_weight,
+            None,
+            True,
+            head_size,
+            out_weight,
+            None,
+            None,
+            1e-5,
+            q_norm_weight,
+            None,
+            k_norm_weight,
+            None,
+            True,
+            1e-5,
+            True,
+            ATTENTION_DROPOUT,
+            PROJECTION_DROPOUT,
+            training,
+            rope,
+        )
+
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        run_attention(full_features, full_rope, training=False)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        output = run_attention(features, masked_rope, training=True)
+    output.square().mean().backward()
+
+    assert global_qkv_weight.grad is not None
+    assert torch.isfinite(global_qkv_weight.grad).all()
+
+
+if __name__ == "__main__":
+    main()

--- a/vit/attention.py
+++ b/vit/attention.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -91,6 +92,69 @@ def project_qkv_packed(
 ) -> tuple[Tensor, Tensor, Tensor]:
     x = apply_norm(x, w_norm, b_norm, eps, use_layer_norm=use_layer_norm)
     q, k, v = F.linear(x, w_in, b_in).chunk(3, dim=-1)
+    q = _unfold_head_and_permute(q, head_dim)
+    k = _unfold_head_and_permute(k, head_dim)
+    q, k = _apply_qk_norm(
+        q,
+        k,
+        q_norm_weight,
+        q_norm_bias,
+        k_norm_weight,
+        k_norm_bias,
+        qk_use_layer_norm,
+        qk_eps,
+        qk_normalization,
+    )
+    if rope is not None:
+        q = apply_rope(q, rope)
+        k = apply_rope(k, rope)
+    v = _unfold_head_and_permute(v, head_dim)
+    return q, k, v
+
+
+@torch.compile(fullgraph=True)
+def project_token_specialized_qkv_packed(
+    # fmt: off
+    x: Tensor,
+    num_global_tokens: int,
+    global_qkv_weight: Tensor,
+    global_qkv_bias: Tensor | None,
+    visual_qkv_weight: Tensor,
+    visual_qkv_bias: Tensor | None,
+    global_norm_weight: Tensor,
+    global_norm_bias: Tensor | None,
+    visual_norm_weight: Tensor,
+    visual_norm_bias: Tensor | None,
+    use_layer_norm: bool,
+    head_dim: int,
+    eps: float,
+    q_norm_weight: Tensor | None,
+    q_norm_bias: Tensor | None,
+    k_norm_weight: Tensor | None,
+    k_norm_bias: Tensor | None,
+    qk_use_layer_norm: bool,
+    qk_eps: float,
+    qk_normalization: bool,
+    rope: Tensor | None = None,
+    # fmt: on
+) -> tuple[Tensor, Tensor, Tensor]:
+    global_features = apply_norm(
+        x[:, :num_global_tokens],
+        global_norm_weight,
+        global_norm_bias,
+        eps,
+        use_layer_norm=use_layer_norm,
+    )
+    visual_features = apply_norm(
+        x[:, num_global_tokens:],
+        visual_norm_weight,
+        visual_norm_bias,
+        eps,
+        use_layer_norm=use_layer_norm,
+    )
+    global_qkv = F.linear(global_features, global_qkv_weight, global_qkv_bias)
+    visual_qkv = F.linear(visual_features, visual_qkv_weight, visual_qkv_bias)
+    q, k, v = torch.cat((global_qkv, visual_qkv), dim=1).chunk(3, dim=-1)
     q = _unfold_head_and_permute(q, head_dim)
     k = _unfold_head_and_permute(k, head_dim)
     q, k = _apply_qk_norm(
@@ -216,6 +280,76 @@ def attention_qkv_packed(
 
 
 @torch.compile(fullgraph=True)
+def attention_token_specialized_qkv_packed(
+    # fmt: off
+    x: Tensor,
+    num_global_tokens: int,
+    global_qkv_weight: Tensor,
+    global_qkv_bias: Tensor | None,
+    visual_qkv_weight: Tensor,
+    visual_qkv_bias: Tensor | None,
+    global_norm_weight: Tensor,
+    global_norm_bias: Tensor | None,
+    visual_norm_weight: Tensor,
+    visual_norm_bias: Tensor | None,
+    use_layer_norm: bool,
+    head_dim: int,
+    w_out: Tensor,
+    b_out: Tensor | None,
+    attn_mask: Tensor | None,
+    eps: float,
+    q_norm_weight: Tensor | None,
+    q_norm_bias: Tensor | None,
+    k_norm_weight: Tensor | None,
+    k_norm_bias: Tensor | None,
+    qk_use_layer_norm: bool,
+    qk_eps: float,
+    qk_normalization: bool,
+    attention_dropout: float,
+    dropout: float,
+    training: bool,
+    rope: Tensor | None = None,
+    # fmt: on
+) -> Tensor:
+    q, k, v = project_token_specialized_qkv_packed(
+        x,
+        num_global_tokens,
+        global_qkv_weight,
+        global_qkv_bias,
+        visual_qkv_weight,
+        visual_qkv_bias,
+        global_norm_weight,
+        global_norm_bias,
+        visual_norm_weight,
+        visual_norm_bias,
+        use_layer_norm,
+        head_dim,
+        eps,
+        q_norm_weight,
+        q_norm_bias,
+        k_norm_weight,
+        k_norm_bias,
+        qk_use_layer_norm,
+        qk_eps,
+        qk_normalization,
+        rope,
+    )
+    attention_dropout = 0.0 if not training else attention_dropout
+    output = F.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        attn_mask=attn_mask,
+        dropout_p=attention_dropout,
+        is_causal=False,
+        enable_gqa=True,
+    )
+    output = _permute_and_fold_head(output)
+    output = F.linear(output, w_out, b_out)
+    return F.dropout(output, p=dropout, training=training, inplace=True)
+
+
+@torch.compile(fullgraph=True)
 def attention_q_kv_packed(
     # fmt: off
     q: Tensor,
@@ -323,6 +457,59 @@ def attention_weights_qkv_packed(
 
 @torch.no_grad()
 @torch.compile(fullgraph=True)
+def attention_weights_token_specialized_qkv_packed(
+    # fmt: off
+    x: Tensor,
+    num_global_tokens: int,
+    global_qkv_weight: Tensor,
+    global_qkv_bias: Tensor | None,
+    visual_qkv_weight: Tensor,
+    visual_qkv_bias: Tensor | None,
+    global_norm_weight: Tensor,
+    global_norm_bias: Tensor | None,
+    visual_norm_weight: Tensor,
+    visual_norm_bias: Tensor | None,
+    use_layer_norm: bool,
+    head_dim: int,
+    eps: float,
+    q_norm_weight: Tensor | None,
+    q_norm_bias: Tensor | None,
+    k_norm_weight: Tensor | None,
+    k_norm_bias: Tensor | None,
+    qk_use_layer_norm: bool,
+    qk_eps: float,
+    qk_normalization: bool,
+    rope: Tensor | None = None,
+    # fmt: on
+) -> Tensor:
+    q, k, _ = project_token_specialized_qkv_packed(
+        x,
+        num_global_tokens,
+        global_qkv_weight,
+        global_qkv_bias,
+        visual_qkv_weight,
+        visual_qkv_bias,
+        global_norm_weight,
+        global_norm_bias,
+        visual_norm_weight,
+        visual_norm_bias,
+        use_layer_norm,
+        head_dim,
+        eps,
+        q_norm_weight,
+        q_norm_bias,
+        k_norm_weight,
+        k_norm_bias,
+        qk_use_layer_norm,
+        qk_eps,
+        qk_normalization,
+        rope,
+    )
+    return (q @ k.mT * (head_dim**-0.5)).softmax(dim=-1)
+
+
+@torch.no_grad()
+@torch.compile(fullgraph=True)
 def attention_weights_q_kv_packed(
     # fmt: off
     q: Tensor,
@@ -389,12 +576,22 @@ class SelfAttention(nn.Module):
         dtype: torch.dtype | None = None,
         norm_type: NormType = "rmsnorm",
         qk_normalization: bool = False,
+        num_global_tokens: int = 0,
+        specialize_norms: bool = False,
+        specialize_qkv: bool = False,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
+        if num_global_tokens < 0:
+            raise ValueError(f"num_global_tokens must be non-negative, got {num_global_tokens}")
+        if (specialize_norms or specialize_qkv) and num_global_tokens == 0:
+            raise ValueError("token specialization requires at least one global token")
+        self.num_global_tokens = num_global_tokens
         self.norm = make_norm(hidden_size, norm_type, eps=eps, **factory_kwargs)
+        self.visual_norm = deepcopy(self.norm) if specialize_norms else None
         self._use_layer_norm = is_layer_norm(norm_type)
         self.qkv_proj = nn.Linear(hidden_size, 3 * hidden_size, bias=bias, **factory_kwargs)
+        self.visual_qkv_proj = deepcopy(self.qkv_proj) if specialize_qkv else None
         self.out_proj = nn.Linear(hidden_size, hidden_size, bias=bias, **factory_kwargs)
         self.dropout = nn.Dropout(hidden_dropout)
         self.attention_dropout = nn.Dropout(attention_dropout)
@@ -408,6 +605,10 @@ class SelfAttention(nn.Module):
     def reset_parameters(self) -> None:
         init_linear(self.qkv_proj)
         init_linear(self.out_proj)
+        if self.visual_norm is not None:
+            self.visual_norm.load_state_dict(self.norm.state_dict())
+        if self.visual_qkv_proj is not None:
+            self.visual_qkv_proj.load_state_dict(self.qkv_proj.state_dict())
         self.apply_quantization(self.qkv_quantization_config, self.out_quantization_config)
 
     def apply_quantization(
@@ -416,11 +617,47 @@ class SelfAttention(nn.Module):
         """Apply quantization to the linear layers using torchao."""
         if qkv_quantization_config is not None:
             quantize_(self.qkv_proj, qkv_quantization_config)
+            if self.visual_qkv_proj is not None:
+                quantize_(self.visual_qkv_proj, qkv_quantization_config)
         if out_quantization_config is not None:
             quantize_(self.out_proj, out_quantization_config)
 
     def forward(self, x: Tensor, attn_mask: Tensor | None = None, rope: Tensor | None = None) -> Tensor:
         q_norm_weight, q_norm_bias, k_norm_weight, k_norm_bias, qk_eps = _get_qk_norm_inputs(self.q_norm, self.k_norm)
+        if self.visual_norm is not None or self.visual_qkv_proj is not None:
+            visual_norm = self.norm if self.visual_norm is None else self.visual_norm
+            visual_qkv_proj = self.qkv_proj if self.visual_qkv_proj is None else self.visual_qkv_proj
+            return attention_token_specialized_qkv_packed(
+                # fmt: off
+                x,
+                self.num_global_tokens,
+                self.qkv_proj.weight,
+                self.qkv_proj.bias,
+                visual_qkv_proj.weight,
+                visual_qkv_proj.bias,
+                self.norm.weight,
+                get_norm_bias(self.norm),
+                visual_norm.weight,
+                get_norm_bias(visual_norm),
+                self._use_layer_norm,
+                self._head_dim,
+                self.out_proj.weight,
+                self.out_proj.bias,
+                attn_mask,
+                self.norm.eps or 1e-5,
+                q_norm_weight,
+                q_norm_bias,
+                k_norm_weight,
+                k_norm_bias,
+                self._use_layer_norm,
+                qk_eps,
+                self._qk_normalization,
+                self.attention_dropout.p,
+                self.dropout.p,
+                self.training,
+                rope,
+                # fmt: on
+            )
         return attention_qkv_packed(
             # fmt: off
             x,
@@ -455,6 +692,34 @@ class SelfAttention(nn.Module):
 
     def forward_weights(self, x: Tensor, rope: Tensor | None = None) -> Tensor:
         q_norm_weight, q_norm_bias, k_norm_weight, k_norm_bias, qk_eps = _get_qk_norm_inputs(self.q_norm, self.k_norm)
+        if self.visual_norm is not None or self.visual_qkv_proj is not None:
+            visual_norm = self.norm if self.visual_norm is None else self.visual_norm
+            visual_qkv_proj = self.qkv_proj if self.visual_qkv_proj is None else self.visual_qkv_proj
+            return attention_weights_token_specialized_qkv_packed(
+                # fmt: off
+                x,
+                self.num_global_tokens,
+                self.qkv_proj.weight,
+                self.qkv_proj.bias,
+                visual_qkv_proj.weight,
+                visual_qkv_proj.bias,
+                self.norm.weight,
+                get_norm_bias(self.norm),
+                visual_norm.weight,
+                get_norm_bias(visual_norm),
+                self._use_layer_norm,
+                self._head_dim,
+                self.norm.eps or 1e-5,
+                q_norm_weight,
+                q_norm_bias,
+                k_norm_weight,
+                k_norm_bias,
+                self._use_layer_norm,
+                qk_eps,
+                self._qk_normalization,
+                rope,
+                # fmt: on
+            )
         return attention_weights_qkv_packed(
             # fmt: off
             x,

--- a/vit/attention.py
+++ b/vit/attention.py
@@ -119,11 +119,11 @@ def project_token_specialized_qkv_packed(
     num_global_tokens: int,
     global_qkv_weight: Tensor,
     global_qkv_bias: Tensor | None,
-    visual_qkv_weight: Tensor,
+    visual_qkv_weight: Tensor | None,
     visual_qkv_bias: Tensor | None,
     global_norm_weight: Tensor,
     global_norm_bias: Tensor | None,
-    visual_norm_weight: Tensor,
+    visual_norm_weight: Tensor | None,
     visual_norm_bias: Tensor | None,
     use_layer_norm: bool,
     head_dim: int,
@@ -138,23 +138,45 @@ def project_token_specialized_qkv_packed(
     rope: Tensor | None = None,
     # fmt: on
 ) -> tuple[Tensor, Tensor, Tensor]:
-    global_features = apply_norm(
-        x[:, :num_global_tokens],
-        global_norm_weight,
-        global_norm_bias,
-        eps,
-        use_layer_norm=use_layer_norm,
-    )
-    visual_features = apply_norm(
-        x[:, num_global_tokens:],
-        visual_norm_weight,
-        visual_norm_bias,
-        eps,
-        use_layer_norm=use_layer_norm,
-    )
-    global_qkv = F.linear(global_features, global_qkv_weight, global_qkv_bias)
-    visual_qkv = F.linear(visual_features, visual_qkv_weight, visual_qkv_bias)
-    q, k, v = torch.cat((global_qkv, visual_qkv), dim=1).chunk(3, dim=-1)
+    if visual_norm_weight is None:
+        normalized_features = apply_norm(
+            x,
+            global_norm_weight,
+            global_norm_bias,
+            eps,
+            use_layer_norm=use_layer_norm,
+        )
+    else:
+        global_features = apply_norm(
+            x[:, :num_global_tokens],
+            global_norm_weight,
+            global_norm_bias,
+            eps,
+            use_layer_norm=use_layer_norm,
+        )
+        visual_features = apply_norm(
+            x[:, num_global_tokens:],
+            visual_norm_weight,
+            visual_norm_bias,
+            eps,
+            use_layer_norm=use_layer_norm,
+        )
+        normalized_features = torch.cat((global_features, visual_features), dim=1)
+    if visual_qkv_weight is None:
+        qkv = F.linear(normalized_features, global_qkv_weight, global_qkv_bias)
+    else:
+        global_qkv = F.linear(
+            normalized_features[:, :num_global_tokens],
+            global_qkv_weight,
+            global_qkv_bias,
+        )
+        visual_qkv = F.linear(
+            normalized_features[:, num_global_tokens:],
+            visual_qkv_weight,
+            visual_qkv_bias,
+        )
+        qkv = torch.cat((global_qkv, visual_qkv), dim=1)
+    q, k, v = qkv.chunk(3, dim=-1)
     q = _unfold_head_and_permute(q, head_dim)
     k = _unfold_head_and_permute(k, head_dim)
     q, k = _apply_qk_norm(
@@ -279,18 +301,18 @@ def attention_qkv_packed(
     return o
 
 
-@torch.compile(fullgraph=True, dynamic=False)
+@torch.compile(fullgraph=True)
 def attention_token_specialized_qkv_packed(
     # fmt: off
     x: Tensor,
     num_global_tokens: int,
     global_qkv_weight: Tensor,
     global_qkv_bias: Tensor | None,
-    visual_qkv_weight: Tensor,
+    visual_qkv_weight: Tensor | None,
     visual_qkv_bias: Tensor | None,
     global_norm_weight: Tensor,
     global_norm_bias: Tensor | None,
-    visual_norm_weight: Tensor,
+    visual_norm_weight: Tensor | None,
     visual_norm_bias: Tensor | None,
     use_layer_norm: bool,
     head_dim: int,
@@ -463,11 +485,11 @@ def attention_weights_token_specialized_qkv_packed(
     num_global_tokens: int,
     global_qkv_weight: Tensor,
     global_qkv_bias: Tensor | None,
-    visual_qkv_weight: Tensor,
+    visual_qkv_weight: Tensor | None,
     visual_qkv_bias: Tensor | None,
     global_norm_weight: Tensor,
     global_norm_bias: Tensor | None,
-    visual_norm_weight: Tensor,
+    visual_norm_weight: Tensor | None,
     visual_norm_bias: Tensor | None,
     use_layer_norm: bool,
     head_dim: int,
@@ -625,20 +647,18 @@ class SelfAttention(nn.Module):
     def forward(self, x: Tensor, attn_mask: Tensor | None = None, rope: Tensor | None = None) -> Tensor:
         q_norm_weight, q_norm_bias, k_norm_weight, k_norm_bias, qk_eps = _get_qk_norm_inputs(self.q_norm, self.k_norm)
         if self.visual_norm is not None or self.visual_qkv_proj is not None:
-            visual_norm = self.norm if self.visual_norm is None else self.visual_norm
-            visual_qkv_proj = self.qkv_proj if self.visual_qkv_proj is None else self.visual_qkv_proj
             return attention_token_specialized_qkv_packed(
                 # fmt: off
                 x,
                 self.num_global_tokens,
                 self.qkv_proj.weight,
                 self.qkv_proj.bias,
-                visual_qkv_proj.weight,
-                visual_qkv_proj.bias,
+                self.visual_qkv_proj.weight if self.visual_qkv_proj is not None else None,
+                self.visual_qkv_proj.bias if self.visual_qkv_proj is not None else None,
                 self.norm.weight,
                 get_norm_bias(self.norm),
-                visual_norm.weight,
-                get_norm_bias(visual_norm),
+                self.visual_norm.weight if self.visual_norm is not None else None,
+                get_norm_bias(self.visual_norm) if self.visual_norm is not None else None,
                 self._use_layer_norm,
                 self._head_dim,
                 self.out_proj.weight,
@@ -693,20 +713,18 @@ class SelfAttention(nn.Module):
     def forward_weights(self, x: Tensor, rope: Tensor | None = None) -> Tensor:
         q_norm_weight, q_norm_bias, k_norm_weight, k_norm_bias, qk_eps = _get_qk_norm_inputs(self.q_norm, self.k_norm)
         if self.visual_norm is not None or self.visual_qkv_proj is not None:
-            visual_norm = self.norm if self.visual_norm is None else self.visual_norm
-            visual_qkv_proj = self.qkv_proj if self.visual_qkv_proj is None else self.visual_qkv_proj
             return attention_weights_token_specialized_qkv_packed(
                 # fmt: off
                 x,
                 self.num_global_tokens,
                 self.qkv_proj.weight,
                 self.qkv_proj.bias,
-                visual_qkv_proj.weight,
-                visual_qkv_proj.bias,
+                self.visual_qkv_proj.weight if self.visual_qkv_proj is not None else None,
+                self.visual_qkv_proj.bias if self.visual_qkv_proj is not None else None,
                 self.norm.weight,
                 get_norm_bias(self.norm),
-                visual_norm.weight,
-                get_norm_bias(visual_norm),
+                self.visual_norm.weight if self.visual_norm is not None else None,
+                get_norm_bias(self.visual_norm) if self.visual_norm is not None else None,
                 self._use_layer_norm,
                 self._head_dim,
                 self.norm.eps or 1e-5,

--- a/vit/attention.py
+++ b/vit/attention.py
@@ -279,7 +279,7 @@ def attention_qkv_packed(
     return o
 
 
-@torch.compile(fullgraph=True)
+@torch.compile(fullgraph=True, dynamic=False)
 def attention_token_specialized_qkv_packed(
     # fmt: off
     x: Tensor,

--- a/vit/explain/trace.py
+++ b/vit/explain/trace.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from vit.attention import _permute_and_fold_head, project_qkv_packed
+from vit.attention import _permute_and_fold_head, project_qkv_packed, project_token_specialized_qkv_packed
 from vit.norm import get_norm_bias
 from vit.patch_embed import PatchEmbed2d
 from vit.tokens import apply_mask
@@ -100,24 +100,49 @@ def eager_self_attention(attention, x: Tensor, rope: Tensor | None) -> tuple[Ten
     k_norm_weight = attention.k_norm.weight if attention.k_norm is not None else None
     k_norm_bias = get_norm_bias(attention.k_norm) if attention.k_norm is not None else None
     qk_eps = attention.q_norm.eps or 1e-5 if attention.q_norm is not None else 1e-5
-    q, k, value = project_qkv_packed(
-        x,
-        attention.qkv_proj.weight,
-        attention.qkv_proj.bias,
-        attention.norm.weight,
-        get_norm_bias(attention.norm),
-        attention._use_layer_norm,
-        attention._head_dim,
-        attention.norm.eps or 1e-5,
-        q_norm_weight,
-        q_norm_bias,
-        k_norm_weight,
-        k_norm_bias,
-        attention._use_layer_norm,
-        qk_eps,
-        attention._qk_normalization,
-        rope,
-    )
+    if attention.visual_norm is not None or attention.visual_qkv_proj is not None:
+        q, k, value = project_token_specialized_qkv_packed(
+            x,
+            attention.num_global_tokens,
+            attention.qkv_proj.weight,
+            attention.qkv_proj.bias,
+            attention.visual_qkv_proj.weight if attention.visual_qkv_proj is not None else None,
+            attention.visual_qkv_proj.bias if attention.visual_qkv_proj is not None else None,
+            attention.norm.weight,
+            get_norm_bias(attention.norm),
+            attention.visual_norm.weight if attention.visual_norm is not None else None,
+            get_norm_bias(attention.visual_norm) if attention.visual_norm is not None else None,
+            attention._use_layer_norm,
+            attention._head_dim,
+            attention.norm.eps or 1e-5,
+            q_norm_weight,
+            q_norm_bias,
+            k_norm_weight,
+            k_norm_bias,
+            attention._use_layer_norm,
+            qk_eps,
+            attention._qk_normalization,
+            rope,
+        )
+    else:
+        q, k, value = project_qkv_packed(
+            x,
+            attention.qkv_proj.weight,
+            attention.qkv_proj.bias,
+            attention.norm.weight,
+            get_norm_bias(attention.norm),
+            attention._use_layer_norm,
+            attention._head_dim,
+            attention.norm.eps or 1e-5,
+            q_norm_weight,
+            q_norm_bias,
+            k_norm_weight,
+            k_norm_bias,
+            attention._use_layer_norm,
+            qk_eps,
+            attention._qk_normalization,
+            rope,
+        )
     probabilities = (q @ k.mT * (attention._head_dim**-0.5)).softmax(dim=-1)
     if not probabilities.requires_grad:
         probabilities.requires_grad_()

--- a/vit/fused.py
+++ b/vit/fused.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -291,10 +292,15 @@ class NormMLP(nn.Module):
         dtype: torch.dtype | None = None,
         norm_type: NormType = "rmsnorm",
         glu_max_autotune_gemm: bool = False,
+        num_global_tokens: int = 0,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
+        if num_global_tokens < 0:
+            raise ValueError(f"num_global_tokens must be non-negative, got {num_global_tokens}")
+        self.num_global_tokens = num_global_tokens
         self.norm = make_norm(hidden_size, norm_type, eps=eps, **factory_kwargs)
+        self.visual_norm = deepcopy(self.norm) if num_global_tokens > 0 else None
         self._use_layer_norm = is_layer_norm(norm_type)
         if activation.endswith("glu"):
             self._is_glu = True
@@ -329,6 +335,40 @@ class NormMLP(nn.Module):
         quantize_(self.fc1, quantization_config)
         quantize_(self.fc2, quantization_config)
 
+    def _normalize_input(
+        self,
+        x: Tensor,
+        norm_scale_delta: Tensor | None,
+        norm_shift: Tensor | None,
+    ) -> Tensor:
+        if self.visual_norm is None:
+            return apply_norm(
+                x,
+                self.norm.weight,
+                get_norm_bias(self.norm),
+                self.norm.eps or 1e-5,
+                use_layer_norm=self._use_layer_norm,
+                scale_delta=norm_scale_delta,
+                shift=norm_shift,
+            )
+        if norm_scale_delta is not None or norm_shift is not None:
+            raise ValueError("token-specialized normalization does not support adaptive norm modulation")
+        global_features = apply_norm(
+            x[:, : self.num_global_tokens],
+            self.norm.weight,
+            get_norm_bias(self.norm),
+            self.norm.eps or 1e-5,
+            use_layer_norm=self._use_layer_norm,
+        )
+        visual_features = apply_norm(
+            x[:, self.num_global_tokens :],
+            self.visual_norm.weight,
+            get_norm_bias(self.visual_norm),
+            self.visual_norm.eps or 1e-5,
+            use_layer_norm=self._use_layer_norm,
+        )
+        return torch.cat((global_features, visual_features), dim=1)
+
     def _forward_with_intermediates(
         self,
         x: Tensor,
@@ -338,15 +378,7 @@ class NormMLP(nn.Module):
         output_gate: Tensor | None = None,
     ) -> _MLPIntermediates:
         """Run the eager MLP path and return graph-connected intermediates."""
-        normalized_input = apply_norm(
-            x,
-            self.norm.weight,
-            get_norm_bias(self.norm),
-            self.norm.eps or 1e-5,
-            use_layer_norm=self._use_layer_norm,
-            scale_delta=norm_scale_delta,
-            shift=norm_shift,
-        )
+        normalized_input = self._normalize_input(x, norm_scale_delta, norm_shift)
         fc1_output = F.linear(normalized_input, self.fc1.weight, self.fc1.bias)
         linear_branch: Tensor | None = None
         gate_branch: Tensor | None = None
@@ -385,6 +417,14 @@ class NormMLP(nn.Module):
         norm_shift: Tensor | None = None,
         output_gate: Tensor | None = None,
     ) -> Tensor:
+        norm_weight: Tensor | None = self.norm.weight
+        norm_bias: Tensor | None = get_norm_bias(self.norm)
+        if self.visual_norm is not None:
+            x = self._normalize_input(x, norm_scale_delta, norm_shift)
+            norm_weight = None
+            norm_bias = None
+            norm_scale_delta = None
+            norm_shift = None
         if self._is_glu:
             glu_forward = norm_mlp_glu
             if (
@@ -400,8 +440,8 @@ class NormMLP(nn.Module):
                 self.fc1.bias,
                 self.fc2.weight,
                 self.fc2.bias,
-                self.norm.weight,
-                get_norm_bias(self.norm),
+                norm_weight,
+                norm_bias,
                 self._use_layer_norm,
                 self.activation,
                 self.norm.eps or 1e-5,
@@ -422,8 +462,8 @@ class NormMLP(nn.Module):
                 self.fc1.bias,
                 self.fc2.weight,
                 self.fc2.bias,
-                self.norm.weight,
-                get_norm_bias(self.norm),
+                norm_weight,
+                norm_bias,
                 self._use_layer_norm,
                 self.activation,
                 self.norm.eps or 1e-5,

--- a/vit/layer_scale.py
+++ b/vit/layer_scale.py
@@ -19,9 +19,9 @@ class LayerScale(nn.Module):
         dim: int,
         init_value: float = 1e-5,
         inplace: bool = False,
-        num_global_tokens: int = 0,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        num_global_tokens: int = 0,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()

--- a/vit/layer_scale.py
+++ b/vit/layer_scale.py
@@ -19,19 +19,30 @@ class LayerScale(nn.Module):
         dim: int,
         init_value: float = 1e-5,
         inplace: bool = False,
+        num_global_tokens: int = 0,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
+        if num_global_tokens < 0:
+            raise ValueError(f"num_global_tokens must be non-negative, got {num_global_tokens}")
         self.inplace = inplace
+        self.num_global_tokens = num_global_tokens
         self.gamma = nn.Parameter(torch.empty(dim, **factory_kwargs))
+        self.visual_gamma = nn.Parameter(torch.empty(dim, **factory_kwargs)) if num_global_tokens > 0 else None
         self.reset_parameters(init_value)
 
     def reset_parameters(self, value: float = 1e-5):
         nn.init.constant_(self.gamma, value)
+        if self.visual_gamma is not None:
+            nn.init.constant_(self.visual_gamma, value)
 
     def forward(self, x: Tensor) -> Tensor:
+        if self.visual_gamma is not None:
+            global_features = layer_scale(x[:, : self.num_global_tokens], self.gamma, self.inplace)
+            visual_features = layer_scale(x[:, self.num_global_tokens :], self.visual_gamma, self.inplace)
+            return torch.cat((global_features, visual_features), dim=1)
         return layer_scale(x, self.gamma, self.inplace)
 
     if TYPE_CHECKING:

--- a/vit/transformer.py
+++ b/vit/transformer.py
@@ -111,6 +111,7 @@ def _make_mlp(
     glu_max_autotune_gemm: bool,
     device: torch.device | None,
     dtype: torch.dtype | None,
+    num_global_tokens: int = 0,
 ) -> NormMLP:
     if conditioning_size is not None:
         return AdaNormMLP(
@@ -142,6 +143,7 @@ def _make_mlp(
         extra_bias=extra_bias,
         quantization_config=quantization_config,
         glu_max_autotune_gemm=glu_max_autotune_gemm,
+        num_global_tokens=num_global_tokens,
         device=device,
         dtype=dtype,
     )
@@ -192,9 +194,14 @@ class TransformerEncoderLayer(nn.Module):
         conditioning_size: int | None = None,
         adaln_gate_init: float = 0.0,
         glu_max_autotune_gemm: bool = False,
+        num_global_tokens: int = 0,
+        specialize_global_token_norms: bool = False,
+        specialize_global_token_qkv: bool = False,
     ):
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
+        if specialize_global_token_norms and conditioning_size is not None:
+            raise ValueError("global-token normalization specialization is incompatible with conditioned MLPs")
         self.drop_path_rate = drop_path_rate
         self.self_attention = SelfAttention(
             hidden_size=hidden_size,
@@ -207,6 +214,9 @@ class TransformerEncoderLayer(nn.Module):
             qkv_quantization_config=None,
             out_quantization_config=None,
             qk_normalization=qk_normalization,
+            num_global_tokens=num_global_tokens,
+            specialize_norms=specialize_global_token_norms,
+            specialize_qkv=specialize_global_token_qkv,
             **factory_kwargs,
         )
         self.mlp = _make_mlp(
@@ -223,16 +233,29 @@ class TransformerEncoderLayer(nn.Module):
             conditioning_size=conditioning_size,
             adaln_gate_init=adaln_gate_init,
             glu_max_autotune_gemm=glu_max_autotune_gemm,
+            num_global_tokens=num_global_tokens if specialize_global_token_norms else 0,
             device=device,
             dtype=dtype,
         )
         self.layer_scale_attn = (
-            LayerScale(hidden_size, layer_scale, inplace=True, **factory_kwargs)
+            LayerScale(
+                hidden_size,
+                layer_scale,
+                inplace=True,
+                num_global_tokens=num_global_tokens if specialize_global_token_norms else 0,
+                **factory_kwargs,
+            )
             if layer_scale is not None
             else nn.Identity()
         )
         self.layer_scale_mlp = (
-            LayerScale(hidden_size, layer_scale, inplace=True, **factory_kwargs)
+            LayerScale(
+                hidden_size,
+                layer_scale,
+                inplace=True,
+                num_global_tokens=num_global_tokens if specialize_global_token_norms else 0,
+                **factory_kwargs,
+            )
             if layer_scale is not None
             else nn.Identity()
         )

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -96,6 +96,8 @@ class ViTConfig:
     drop_path_rate: float = 0.0
     num_register_tokens: int = 0
     num_cls_tokens: int = 0
+    specialize_global_token_norms: bool = False
+    specialize_global_token_qkv_blocks: int = 0
     pos_enc: PositionEncoder = "rope"
     layer_scale: float | None = None
     glu_limit: float | None = None
@@ -140,6 +142,15 @@ class ViTConfig:
             raise ValueError(f"hidden_size ({self.hidden_size}) must be even when using Fourier positional encoding")
         if self.conditioning_size is not None and self.conditioning_size <= 0:
             raise ValueError(f"conditioning_size must be positive when provided, got {self.conditioning_size}")
+        if self.specialize_global_token_qkv_blocks < 0:
+            raise ValueError("specialize_global_token_qkv_blocks must be non-negative")
+        if self.specialize_global_token_qkv_blocks > self.depth:
+            raise ValueError("specialize_global_token_qkv_blocks cannot exceed depth")
+        specialization_enabled = self.specialize_global_token_norms or self.specialize_global_token_qkv_blocks > 0
+        if specialization_enabled and self.num_cls_tokens + self.num_register_tokens == 0:
+            raise ValueError("global-token specialization requires at least one CLS or register token")
+        if self.specialize_global_token_norms and self.conditioning_size is not None:
+            raise ValueError("global-token normalization specialization is incompatible with conditioned MLPs")
         if self.glu_max_autotune_gemm and not self.activation.endswith("glu"):
             raise ValueError("glu_max_autotune_gemm requires a GLU activation")
         validate_adaln_gate_init(self.adaln_gate_init)
@@ -328,9 +339,13 @@ class ViT(nn.Module):
         self.blocks = nn.ModuleList(
             [
                 self.create_encoder_layer(
-                    mlp_quantization_config, qkv_quantization_config, attn_quantization_config, device
+                    mlp_quantization_config,
+                    qkv_quantization_config,
+                    attn_quantization_config,
+                    device,
+                    block_index=block_index,
                 )
-                for _ in range(config.depth)
+                for block_index in range(config.depth)
             ]
         )
         self.output_norm = make_norm(config.hidden_size, config.norm_type, device=device, dtype=config.dtype)
@@ -366,6 +381,7 @@ class ViT(nn.Module):
         attn_quantization_config: Any | None = None,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        block_index: int = 0,
     ) -> TransformerEncoderLayer:
         resolved_dtype = self._resolve_factory_dtype(dtype)
         return TransformerEncoderLayer(
@@ -391,6 +407,9 @@ class ViT(nn.Module):
             conditioning_size=self.config.conditioning_size,
             adaln_gate_init=self.config.adaln_gate_init,
             glu_max_autotune_gemm=self.config.glu_max_autotune_gemm,
+            num_global_tokens=self.config.num_cls_tokens + self.config.num_register_tokens,
+            specialize_global_token_norms=self.config.specialize_global_token_norms,
+            specialize_global_token_qkv=block_index < self.config.specialize_global_token_qkv_blocks,
         )
 
     def create_decoder_layer(

--- a/vit/vit.py
+++ b/vit/vit.py
@@ -76,6 +76,12 @@ class ViTConfig:
     for the default AdaLN-Zero initialization. Set `adaln_gate_init=1.0` when
     converting a pretrained unconditioned MLP stack into a conditioned one so the
     loaded MLP path is preserved at initialization.
+
+    Set `specialize_global_token_norms=True` to give the CLS/register prefix and
+    visual tokens independent pre-attention and pre-MLP norms. Configured LayerScale
+    parameters are separated with them. Set `specialize_global_token_qkv_blocks` to
+    the number of leading blocks that also receive independent QKV projections. Both
+    options are disabled by default, preserving the shared-token-path architecture.
     """
 
     # Inputs
@@ -96,8 +102,6 @@ class ViTConfig:
     drop_path_rate: float = 0.0
     num_register_tokens: int = 0
     num_cls_tokens: int = 0
-    specialize_global_token_norms: bool = False
-    specialize_global_token_qkv_blocks: int = 0
     pos_enc: PositionEncoder = "rope"
     layer_scale: float | None = None
     glu_limit: float | None = None
@@ -129,6 +133,10 @@ class ViTConfig:
     # Heads
     heads: dict[str, HeadConfigType] = field(default_factory=dict)
 
+    # Global and visual token pathways
+    specialize_global_token_norms: bool = False
+    specialize_global_token_qkv_blocks: int = 0
+
     def __post_init__(self) -> None:
         """Validate configuration parameters."""
         if self.hidden_size % self.num_attention_heads != 0:
@@ -146,14 +154,23 @@ class ViTConfig:
             raise ValueError("specialize_global_token_qkv_blocks must be non-negative")
         if self.specialize_global_token_qkv_blocks > self.depth:
             raise ValueError("specialize_global_token_qkv_blocks cannot exceed depth")
-        specialization_enabled = self.specialize_global_token_norms or self.specialize_global_token_qkv_blocks > 0
-        if specialization_enabled and self.num_cls_tokens + self.num_register_tokens == 0:
+        if self.token_specialization_enabled and self.num_global_tokens == 0:
             raise ValueError("global-token specialization requires at least one CLS or register token")
         if self.specialize_global_token_norms and self.conditioning_size is not None:
             raise ValueError("global-token normalization specialization is incompatible with conditioned MLPs")
         if self.glu_max_autotune_gemm and not self.activation.endswith("glu"):
             raise ValueError("glu_max_autotune_gemm requires a GLU activation")
         validate_adaln_gate_init(self.adaln_gate_init)
+
+    @property
+    def num_global_tokens(self) -> int:
+        """Return the CLS/register prefix length used by token specialization."""
+        return self.num_cls_tokens + self.num_register_tokens
+
+    @property
+    def token_specialization_enabled(self) -> bool:
+        """Return whether any global/visual token pathway is separated."""
+        return self.specialize_global_token_norms or self.specialize_global_token_qkv_blocks > 0
 
     def instantiate(self, device: torch.device | None = None) -> "ViT":
         return ViT(self, device=device)
@@ -338,12 +355,12 @@ class ViT(nn.Module):
 
         self.blocks = nn.ModuleList(
             [
-                self.create_encoder_layer(
+                self._create_encoder_block(
+                    block_index,
                     mlp_quantization_config,
                     qkv_quantization_config,
                     attn_quantization_config,
                     device,
-                    block_index=block_index,
                 )
                 for block_index in range(config.depth)
             ]
@@ -373,6 +390,30 @@ class ViT(nn.Module):
 
     def _resolve_factory_dtype(self, dtype: torch.dtype | None) -> torch.dtype:
         return self.config.dtype if dtype is None else dtype
+
+    def _create_encoder_block(
+        self,
+        block_index: int,
+        mlp_quantization_config: Any | None,
+        qkv_quantization_config: Any | None,
+        attn_quantization_config: Any | None,
+        device: torch.device | None,
+    ) -> TransformerEncoderLayer:
+        if self.config.token_specialization_enabled:
+            return self.create_encoder_layer(
+                mlp_quantization_config,
+                qkv_quantization_config,
+                attn_quantization_config,
+                device,
+                block_index=block_index,
+            )
+        # Keep the historical factory call unchanged for subclasses when the new feature is disabled.
+        return self.create_encoder_layer(
+            mlp_quantization_config,
+            qkv_quantization_config,
+            attn_quantization_config,
+            device,
+        )
 
     def create_encoder_layer(
         self,
@@ -407,7 +448,7 @@ class ViT(nn.Module):
             conditioning_size=self.config.conditioning_size,
             adaln_gate_init=self.config.adaln_gate_init,
             glu_max_autotune_gemm=self.config.glu_max_autotune_gemm,
-            num_global_tokens=self.config.num_cls_tokens + self.config.num_register_tokens,
+            num_global_tokens=self.config.num_global_tokens,
             specialize_global_token_norms=self.config.specialize_global_token_norms,
             specialize_global_token_qkv=block_index < self.config.specialize_global_token_qkv_blocks,
         )


### PR DESCRIPTION
## Summary

- Add opt-in global/visual token normalization pathways to every encoder block.
- Allow a configurable number of leading blocks to use separate visual-token QKV projections.
- Preserve shared attention, output projections, MLP projections, and the final output normalization.
- Keep the historical model behavior, parameter set, factory calls, and `ViTFeatures` output contract when specialization is disabled.

## Configuration

```python
config = ViTConfig(
    # Existing model parameters...
    num_cls_tokens=1,
    num_register_tokens=7,
    specialize_global_token_norms=True,
    specialize_global_token_qkv_blocks=4,
)
```

Both new options default to disabled. Specialized branches are cloned from the shared branches during construction, so a freshly initialized specialized model begins with the same function as its shared-path counterpart.

## Implementation notes

- Split pre-attention and pre-MLP normalization parameters, plus LayerScale when configured, between the CLS/register prefix and visual tokens.
- Split only the QKV projection in the configured leading blocks; all tokens continue to participate in the same attention operation.
- Keep one QKV GEMM in norm-only specialized blocks instead of executing duplicate projections with aliased weights.
- Append new public constructor options so existing positional arguments retain their previous meaning.
- Preserve the historical `create_encoder_layer` call shape for default configurations and subclasses.
- Cover independent configuration, validation, masked forwards, attention tracing, activation checkpointing, quantization, initialization equivalence, gradient separation, and compiled CUDA backward behavior.

## Test plan

- `make check`
- `uv run pytest tests/test_token_specialization.py -m 'not cuda and not compile' -q`
- `uv run pytest tests/test_token_specialization.py -m 'cuda and compile' -q`

Generated with Codex.
